### PR TITLE
Update arduino-ci-script subtree to 1.0.0 tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: required
 env:
   global:
     # The Arduino IDE will be installed at ${APPLICATION_FOLDER}/arduino
-    - APPLICATION_FOLDER="/usr/local/share"
+    - APPLICATION_FOLDER="${HOME}/arduino-ide"
     - SKETCHBOOK_FOLDER="${HOME}/Arduino"
 
 

--- a/travis-ci/arduino-ci-script/.travis.yml
+++ b/travis-ci/arduino-ci-script/.travis.yml
@@ -1,40 +1,39 @@
 # This file is used to test the script with Travis CI
 
 language: bash
-sudo: required
 
 
 env:
   global:
     # The Arduino IDE will be installed at APPLICATION_FOLDER/arduino
-    - APPLICATION_FOLDER="/usr/local/share"
-    - SKETCHBOOK_FOLDER="${HOME}/Arduino"
+    - APPLICATION_FOLDER="${HOME}/arduino-ide"
+    - SKETCHBOOK_FOLDER="${HOME}/arduino-sketchbook"
 
   matrix:
     # Test install_ide with no argument (using full version list). This would cause the Travis CI build to take much longer so I have it disabled
     # - INSTALL_IDE_START_VERSION=""
     # Test install_ide using full version list
-    - INSTALL_IDE_START_VERSION="all"
+    - INSTALL_IDE_START_VERSION="all" SCRIPT_VERBOSITY_LEVEL=0 VERBOSE_COMPILATION="false"
     # Test install_ide using custom version list. Test the use of the special version names "oldest" and "newest" in a version list. Test use of "hourly" version name.
-    - INSTALL_IDE_START_VERSION='("oldest" "1.8.1" "newest" "hourly")'
+    - INSTALL_IDE_START_VERSION='("oldest" "1.8.1" "1.8.2" "newest" "hourly")' VERBOSITY_LEVEL=1 VERBOSE_COMPILATION="true"
     # Allowed to fail
     # Test install_ide using single version
     # test the failure behavior of install_package when a Boards Manager installation is attempted using an IDE version that doesn't support it.
-    - INSTALL_IDE_START_VERSION="1.6.3"
+    - INSTALL_IDE_START_VERSION="1.6.3" VERBOSITY_LEVEL=2 VERBOSE_COMPILATION="false"
     # Test install_ide using version range. Test the use of the special version names "oldest" and "newest" in a version range.
-    - INSTALL_IDE_START_VERSION="oldest" INSTALL_IDE_END_VERSION="newest"
+    - INSTALL_IDE_START_VERSION="oldest" INSTALL_IDE_END_VERSION="newest" VERBOSITY_LEVEL=0 VERBOSE_COMPILATION="false"
 
 
 matrix:
   allow_failures:
     # The expected behavior is failure because 1.6.3 doesn't support boards manager installation.
-    - env: INSTALL_IDE_START_VERSION="1.6.3"
+    - env: INSTALL_IDE_START_VERSION="1.6.3" VERBOSITY_LEVEL=2 VERBOSE_COMPILATION="false"
 
 
 before_install:
   - source "${TRAVIS_BUILD_DIR}/arduino-ci-script.sh"
 
-  - set_script_verbosity 0
+  - set_script_verbosity "$VERBOSITY_LEVEL"
 
   - set_application_folder "$APPLICATION_FOLDER"
   - set_sketchbook_folder "$SKETCHBOOK_FOLDER"
@@ -42,19 +41,20 @@ before_install:
   # Check for board definition errors that don't affect compilation
   - set_board_testing "true"
 
+  # Check for library issues that don't affect compilation
+  - set_library_testing "true"
+
   - install_ide "$INSTALL_IDE_START_VERSION" "$INSTALL_IDE_END_VERSION"
 
   # Install hardware packages
   # Test package install from this repository (can't do this because the repository isn't a hardware package)
   # - install_package
-  # Test Boards Manager package install without URL. Test error handling of attempting to do a Boards Manager installation when the newest installed IDE version doesn't support it (should print a helpful error message and fail instead of hanging).
-  - install_package "arduino:sam"
-  # Test Boards Manager package install with URL
-  - install_package "MiniCore:avr" "https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json"
   # Test manual package install from compressed file download
   - install_package "https://github.com/SpenceKonde/ATTinyCore/archive/master.zip"
   # Test manual package install from Git repository clone
   - install_package "https://github.com/MCUdude/MightyCore.git"
+  # Test manual package install from Git repository clone
+  - install_package "https://github.com/JChristensen/mighty-1284p.git" "v1.6.3"
 
   # Test library installation from repository (can't do this because there is no library in this repository)
   # - install_library
@@ -64,12 +64,24 @@ before_install:
   - install_library "https://github.com/brianc118/MPU9250/archive/master.zip" "MPU9250"
   # Test library install from git repo
   - install_library "https://github.com/sfrwmaker/WirelessOregonV2.git"
+  # Test library install from git repo with branch
+  - install_library "https://github.com/sde1000/NanodeUNIO.git" "master"
   # Test library install from git repo with rename
-  - install_library "https://github.com/mikaelpatel/Arduino-Shell.git" "ArduinoShell"
+  - install_library "https://github.com/mikaelpatel/Arduino-Shell.git" "" "ArduinoShell"
+  # Test library install from git repo with branch and rename
+  - install_library "https://github.com/Avamander/max7456.git" "master" "max_7456"
+  # Test set_verbose_output_during_compilation.
+  - set_verbose_output_during_compilation "$VERBOSE_COMPILATION"
+
+  # Boards Manager and Library Manager tests are done as late as possible to allow job 3 to do more thorough testing of script verbosity level 2 before the job fails
+
+  # Test Boards Manager package install without URL. Test error handling of attempting to do a Boards Manager installation when the newest installed IDE version doesn't support it (should print a helpful error message and fail instead of hanging).
+  - install_package "arduino:sam"
+  # Test Boards Manager package install with URL
+  - install_package "MiniCore:avr" "https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json"
+
   # Test library install from Library Manager
   - install_library "Pushetta:1.0.1"
-  # Test set_verbose_output_during_compilation. Setting verbose output to false is not actually necessary but it tests the function.
-  - set_verbose_output_during_compilation "false"
 
 
 script:
@@ -90,6 +102,8 @@ script:
   # Test board from hardware package manually installed by cloning Git repository
   # Test build_sketch with an IDE version range
   - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "MightyCore:avr:1284:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" "false" "1.8.1" "1.8.2"
+  # Test board from hardware package manually installed by cloning Git repository with non-default branch
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "mighty-1284p:avr:avr_developers" "false" "newest"
 
   # Installed library tests:
   # Test build_sketch without absolute path
@@ -101,8 +115,12 @@ script:
   - build_sketch "${SKETCHBOOK_FOLDER}/libraries/NewPing/examples/NewPingExample/NewPingExample.pde" "arduino:avr:uno" "false" "all"
   # Test library installed from .git
   - build_sketch "${SKETCHBOOK_FOLDER}/libraries/WirelessOregonV2/examples/OregonReceiver/OregonReceiver.ino" "arduino:avr:uno" "false" "newest"
+  # Test library installed from .git with branch
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/NanodeUNIO/examples/NanodeUNIO_test/NanodeUNIO_test.pde" "arduino:avr:uno" "false" "newest"
   # Test library installed from .git with rename
   - build_sketch "${SKETCHBOOK_FOLDER}/libraries/ArduinoShell/examples/ShellBlink/ShellBlink.ino" "arduino:avr:uno" "false" "newest"
+  # Test library installed from .git with branch and rename
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/max_7456/examples/HelloWorld/HelloWorld.ino" "arduino:avr:uno" "false" "newest"
   # Test library installed from Library Manager
   - build_sketch "${SKETCHBOOK_FOLDER}/libraries/Pushetta/examples/simple_notification/simple_notification.ino" "arduino:avr:uno" "false" "newest"
 
@@ -129,8 +147,8 @@ script:
   - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false" '("1.8.1" "1.8.2")'
   # Test build_sketch with folder argument with an IDE version range
   - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false" "1.8.1" "1.8.2"
-  # Test build_sketch with folder argument allowed to fail (this will fail because WirelessOregonV2 is AVR specific)
-  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/WirelessOregonV2/examples" "arduino:sam:arduino_due_x_dbg" "true" "newest"
+  # Test build_sketch with folder argument required to fail (this will fail because WirelessOregonV2 is AVR specific)
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/WirelessOregonV2/examples" "arduino:sam:arduino_due_x_dbg" "require" "newest"
 
   - publish_report_to_gist "$REPORT_GITHUB_TOKEN" "$REPORT_GIST_URL" "true"
 

--- a/travis-ci/arduino-ci-script/arduino-ci-script.sh
+++ b/travis-ci/arduino-ci-script/arduino-ci-script.sh
@@ -3,86 +3,73 @@
 # https://github.com/per1234/arduino-ci-script
 
 
-# Save the location of the script
-# http://stackoverflow.com/a/246128/7059512
-ARDUINO_CI_SCRIPT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-
 # Based on https://github.com/adafruit/travis-ci-arduino/blob/eeaeaf8fa253465d18785c2bb589e14ea9893f9f/install.sh#L11
 # It seems that arrays can't been seen in other functions. So instead I'm setting $IDE_VERSIONS to a string that is the command to create the array
-IDE_VERSION_LIST_ARRAY_DECLARATION="declare -a IDEversionListArray="
+readonly ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION="declare -a -r IDEversionListArray="
 
 # https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#history shows CLI was added in IDE 1.5.2, Boards and Library Manager support added in 1.6.4
 # This is a list of every version of the Arduino IDE that supports CLI. As new versions are released they will be added to the list.
 # The newest IDE version must always be placed at the end of the array because the code for setting $NEWEST_INSTALLED_IDE_VERSION assumes that
 # Arduino IDE 1.6.2 has the nasty behavior of moving the included hardware cores to the .arduino15 folder, causing those versions to be used for all builds after Arduino IDE 1.6.2 is used. For this reason 1.6.2 has been left off the list.
-FULL_IDE_VERSION_LIST_ARRAY="${IDE_VERSION_LIST_ARRAY_DECLARATION}"'("1.5.2" "1.5.3" "1.5.4" "1.5.5" "1.5.6" "1.5.6-r2" "1.5.7" "1.5.8" "1.6.0" "1.6.1" "1.6.3" "1.6.4" "1.6.5" "1.6.5-r4" "1.6.5-r5" "1.6.6" "1.6.7" "1.6.8" "1.6.9" "1.6.10" "1.6.11" "1.6.12" "1.6.13" "1.8.0" "1.8.1" "1.8.2" "hourly")'
+readonly ARDUINO_CI_SCRIPT_FULL_IDE_VERSION_LIST_ARRAY="${ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION}"'("1.5.2" "1.5.3" "1.5.4" "1.5.5" "1.5.6" "1.5.6-r2" "1.5.7" "1.5.8" "1.6.0" "1.6.1" "1.6.3" "1.6.4" "1.6.5" "1.6.5-r4" "1.6.5-r5" "1.6.6" "1.6.7" "1.6.8" "1.6.9" "1.6.10" "1.6.11" "1.6.12" "1.6.13" "1.8.0" "1.8.1" "1.8.2" "1.8.3" "hourly")'
 
 
-TEMPORARY_FOLDER="${HOME}/temporary/arduino-ci-script"
-VERIFICATION_OUTPUT_FILENAME="${TEMPORARY_FOLDER}/verification_output.txt"
-REPORT_FILENAME="travis_ci_job_report_$(printf "%05d\n" "${TRAVIS_BUILD_NUMBER}").$(printf "%03d\n" "$(echo "$TRAVIS_JOB_NUMBER" | cut -d'.' -f 2)").tsv"
-REPORT_FOLDER="${HOME}/arduino-ci-script_report"
-REPORT_FILE_PATH="${REPORT_FOLDER}/${REPORT_FILENAME}"
-# The arduino manpage(https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#exit-status) documents a range of exit codes. These exit codes indicate success, invalid arduino command, or compilation failed due to legitimate code errors. arduino sometimes returns other exit codes that may indicate problems that may go away after a retry.
-HIGHEST_ACCEPTABLE_ARDUINO_EXIT_CODE=4
-SKETCH_VERIFY_RETRIES=3
-REPORT_PUSH_RETRIES=10
+readonly ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER="${HOME}/temporary/arduino-ci-script"
+readonly ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER="arduino"
+readonly ARDUINO_CI_SCRIPT_VERIFICATION_OUTPUT_FILENAME="${ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER}/verification_output.txt"
+readonly ARDUINO_CI_SCRIPT_REPORT_FILENAME="travis_ci_job_report_$(printf "%05d\n" "${TRAVIS_BUILD_NUMBER}").$(printf "%03d\n" "$(echo "$TRAVIS_JOB_NUMBER" | cut -d'.' -f 2)").tsv"
+readonly ARDUINO_CI_SCRIPT_REPORT_FOLDER="${HOME}/arduino-ci-script_report"
+readonly ARDUINO_CI_SCRIPT_REPORT_FILE_PATH="${ARDUINO_CI_SCRIPT_REPORT_FOLDER}/${ARDUINO_CI_SCRIPT_REPORT_FILENAME}"
+# The arduino manpage(https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#exit-status) documents a range of exit statuses. These exit statuses indicate success, invalid arduino command, or compilation failed due to legitimate code errors. arduino sometimes returns other exit statuses that may indicate problems that may go away after a retry.
+readonly ARDUINO_CI_SCRIPT_HIGHEST_ACCEPTABLE_ARDUINO_EXIT_STATUS=4
+readonly ARDUINO_CI_SCRIPT_SKETCH_VERIFY_RETRIES=3
+readonly ARDUINO_CI_SCRIPT_REPORT_PUSH_RETRIES=10
+
+readonly ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS=0
+readonly ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS=1
+
+# Default value
+ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT=0
 
 
 # Create the folder if it doesn't exist
 function create_folder()
 {
-  local folderName="$1"
+  local -r folderName="$1"
   if ! [[ -d "$folderName" ]]; then
-    mkdir --parents "$folderName"
+    # shellcheck disable=SC2086
+    mkdir --parents $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "$folderName"
   fi
 }
-
-
-# Create the temporary folder
-create_folder "$TEMPORARY_FOLDER"
-
-# Create the report folder
-create_folder "$REPORT_FOLDER"
-
-
-# Add column names to report
-echo "Build Timestamp (UTC)"$'\t'"Build"$'\t'"Job"$'\t'"Job URL"$'\t'"Build Trigger"$'\t'"Allow Job Failure"$'\t'"PR#"$'\t'"Branch"$'\t'"Commit"$'\t'"Commit Range"$'\t'"Commit Message"$'\t'"Sketch Filename"$'\t'"Board ID"$'\t'"IDE Version"$'\t'"Program Storage (bytes)"$'\t'"Dynamic Memory (bytes)"$'\t'"# Warnings"$'\t'"Allow Failure"$'\t'"Exit Code"$'\t'"Board Error"$'\r' > "$REPORT_FILE_PATH"
-
-
-# Start the virtual display required by the Arduino IDE CLI: https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#bugs
-# based on https://learn.adafruit.com/continuous-integration-arduino-and-you/testing-your-project
-/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
-sleep 3
-export DISPLAY=:1.0
 
 
 function set_script_verbosity()
 {
   enable_verbosity
 
-  SCRIPT_VERBOSITY_LEVEL="$1"
+  ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL="$1"
 
-  if [[ "$SCRIPT_VERBOSITY_LEVEL" == "true" ]]; then
-    SCRIPT_VERBOSITY_LEVEL=1
+  if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" == "true" ]]; then
+    ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL=1
   fi
 
-  if [[ "$SCRIPT_VERBOSITY_LEVEL" == 1 ]]; then
-    VERBOSITY_OPTION="--verbose"
+  if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -eq 1 ]]; then
+    ARDUINO_CI_SCRIPT_VERBOSITY_OPTION="--verbose"
+    ARDUINO_CI_SCRIPT_QUIET_OPTION=""
     # Show stderr only
-    VERBOSITY_REDIRECT="1>/dev/null"
-  elif [[ "$SCRIPT_VERBOSITY_LEVEL" == 2 ]]; then
-    VERBOSE_SCRIPT_OUTPUT="true"
-    MORE_VERBOSE_SCRIPT_OUTPUT="true"
-    VERBOSITY_OPTION="--verbose"
+    ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT="1>/dev/null"
+  elif [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -eq 2 ]]; then
+    ARDUINO_CI_SCRIPT_VERBOSITY_OPTION="--verbose"
+    ARDUINO_CI_SCRIPT_QUIET_OPTION=""
     # Show stdout and stderr
-    VERBOSITY_REDIRECT=""
+    ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT=""
   else
-    SCRIPT_VERBOSITY_LEVEL=0
-    VERBOSITY_OPTION=""
+    ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL=0
+    ARDUINO_CI_SCRIPT_VERBOSITY_OPTION=""
+    # cabextract only takes the short option name so this is more universally useful than --quiet
+    ARDUINO_CI_SCRIPT_QUIET_OPTION="-q"
     # Don't show stderr or stdout
-    VERBOSITY_REDIRECT="&>/dev/null"
+    ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT="&>/dev/null"
   fi
 
   disable_verbosity
@@ -92,43 +79,33 @@ function set_script_verbosity()
 # Deprecated, use set_script_verbosity
 function set_verbose_script_output()
 {
-  enable_verbosity
-
-  if [[ "$VERBOSE_SCRIPT_OUTPUT" == "true" ]]; then
-    set_script_verbosity 1
-  else
-    set_script_verbosity 0
-  fi
-
-  disable_verbosity
+  set_script_verbosity 1
 }
 
 
 # Deprecated, use set_script_verbosity
 function set_more_verbose_script_output()
 {
-  enable_verbosity
-
-  if [[ "$MORE_VERBOSE_SCRIPT_OUTPUT" == "true" ]]; then
-    set_script_verbosity 2
-  else
-    set_script_verbosity 0
-  fi
-
-  disable_verbosity
+  set_script_verbosity 2
 }
 
 
 # Turn on verbosity based on the preferences set by set_script_verbosity
 function enable_verbosity()
 {
-  if [[ "$SCRIPT_VERBOSITY_LEVEL" -gt 0 ]]; then
+  # Store previous verbosity settings so they can be set back to their original values at the end of the function
+  shopt -q -o verbose
+  ARDUINO_CI_SCRIPT_PREVIOUS_VERBOSE_SETTING="$?"
+
+  shopt -q -o xtrace
+  ARDUINO_CI_SCRIPT_PREVIOUS_XTRACE_SETTING="$?"
+
+  if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -gt 0 ]]; then
     # "Print shell input lines as they are read."
     # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
     set -o verbose
   fi
-  if [[ "$SCRIPT_VERBOSITY_LEVEL" -gt 1 ]]; then
-    set -o verbose
+  if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -gt 1 ]]; then
     # "Print a trace of simple commands, for commands, case commands, select commands, and arithmetic for commands and their arguments or associated word lists after they are expanded and before they are executed. The value of the PS4 variable is expanded and the resultant value is printed before the command and its expanded arguments."
     # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
     set -o xtrace
@@ -136,23 +113,45 @@ function enable_verbosity()
 }
 
 
-# Turn off verbosity based on the preferences set by set_verbose_script_output and set_more_verbose_script_output
+# Return verbosity settings to their previous values
 function disable_verbosity()
 {
-  set +o verbose
-  set +o xtrace
+  if [[ "$ARDUINO_CI_SCRIPT_PREVIOUS_VERBOSE_SETTING" == "0" ]]; then
+    set -o verbose
+  else
+    set +o verbose
+  fi
+
+  if [[ "$ARDUINO_CI_SCRIPT_PREVIOUS_XTRACE_SETTING" == "0" ]]; then
+    set -o xtrace
+  else
+    set +o xtrace
+  fi
 }
 
 
-# Set default verbosity (must be called after the function definitions
-set_script_verbosity 0
+# Verbosity and, in some cases, errexit must be disabled before an early return from a public function, this allows it to be done in a single line instead of two
+function return_handler()
+{
+  local -r exitStatus="$1"
+
+  # If exit status is success and errexit is enabled then it must be disabled before exiting the script because errexit must be disabled by default and only enabled in the functions that specifically require it.
+  # If exit status is not success then errexit should not be disabled, otherwise Travis CI won't fail the build even though the exit status was failure.
+  if [[ "$exitStatus" == "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]] && shopt -q -o errexit; then
+      set +o errexit
+  fi
+
+  disable_verbosity
+
+  return "$exitStatus"
+}
 
 
 function set_application_folder()
 {
   enable_verbosity
 
-  APPLICATION_FOLDER="$1"
+  ARDUINO_CI_SCRIPT_APPLICATION_FOLDER="$1"
 
   disable_verbosity
 }
@@ -162,10 +161,15 @@ function set_sketchbook_folder()
 {
   enable_verbosity
 
-  SKETCHBOOK_FOLDER="$1"
+  ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER="$1"
 
   # Create the sketchbook folder if it doesn't already exist
-  create_folder "$SKETCHBOOK_FOLDER"
+  create_folder "$ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER"
+
+  # Set sketchbook location preference if the IDE is already installed
+  if [[ "$INSTALLED_IDE_VERSION_LIST_ARRAY" != "" ]]; then
+    set_ide_preference "sketchbook.path=$ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER"
+  fi
 
   disable_verbosity
 }
@@ -174,12 +178,8 @@ function set_sketchbook_folder()
 # Deprecated
 function set_parameters()
 {
-  enable_verbosity
-
   set_application_folder "$1"
   set_sketchbook_folder "$2"
-
-  disable_verbosity
 }
 
 
@@ -188,7 +188,18 @@ function set_board_testing()
 {
   enable_verbosity
 
-  TEST_BOARD="$1"
+  ARDUINO_CI_SCRIPT_TEST_BOARD="$1"
+
+  disable_verbosity
+}
+
+
+# Check for errors with libraries that don't affect sketch verification
+function set_library_testing()
+{
+  enable_verbosity
+
+  ARDUINO_CI_SCRIPT_TEST_LIBRARY="$1"
 
   disable_verbosity
 }
@@ -199,20 +210,25 @@ function install_ide()
 {
   enable_verbosity
 
-  local startIDEversion="$1"
-  local endIDEversion="$2"
+  local -r startIDEversion="$1"
+  local -r endIDEversion="$2"
 
   # https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
-  # set -o errexit will cause the script to exit as soon as any command returns a non-zero exit code. Without this the success of the function call is determined by the exit code of the last command in the function
+  # set -o errexit will cause the script to exit as soon as any command returns a non-zero exit status. Without this the success of the function call is determined by the exit status of the last command in the function
   set -o errexit
 
-  generate_ide_version_list_array "$FULL_IDE_VERSION_LIST_ARRAY" "$startIDEversion" "$endIDEversion"
-  INSTALLED_IDE_VERSION_LIST_ARRAY="$GENERATED_IDE_VERSION_LIST_ARRAY"
+  generate_ide_version_list_array "$ARDUINO_CI_SCRIPT_FULL_IDE_VERSION_LIST_ARRAY" "$startIDEversion" "$endIDEversion"
+  INSTALLED_IDE_VERSION_LIST_ARRAY="$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"
 
   # Set "$NEWEST_INSTALLED_IDE_VERSION"
   determine_ide_version_extremes "$INSTALLED_IDE_VERSION_LIST_ARRAY"
-  NEWEST_INSTALLED_IDE_VERSION="$DETERMINED_NEWEST_IDE_VERSION"
+  NEWEST_INSTALLED_IDE_VERSION="$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
 
+  if [[ "$ARDUINO_CI_SCRIPT_APPLICATION_FOLDER" == "" ]]; then
+    echo "ERROR: Application folder was not set. Please use the set_application_folder function to define the location of the application folder."
+    return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  fi
+  create_folder "$ARDUINO_CI_SCRIPT_APPLICATION_FOLDER"
 
   # This runs the command contained in the $INSTALLED_IDE_VERSION_LIST_ARRAY string, thus declaring the array locally as $IDEversionListArray. This must be done in any function that uses the array
   # Dummy declaration to fix the "referenced but not assigned" warning.
@@ -221,8 +237,8 @@ function install_ide()
   local IDEversion
   for IDEversion in "${IDEversionListArray[@]}"; do
     # Determine download file extension
-    local regex="1.5.[0-9]"
-    if [[ "$IDEversion" =~ $regex ]]; then
+    local tgzExtensionVersionsRegex="1.5.[0-9]"
+    if [[ "$IDEversion" =~ $tgzExtensionVersionsRegex ]]; then
       # The download file extension prior to 1.6.0 is .tgz
       local downloadFileExtension="tgz"
     else
@@ -231,43 +247,23 @@ function install_ide()
 
     if [[ "$IDEversion" == "hourly" ]]; then
       # Deal with the inaccurate name given to the hourly build download
-      wget "http://downloads.arduino.cc/arduino-nightly-linux64.${downloadFileExtension}"
-      tar xf "arduino-nightly-linux64.${downloadFileExtension}"
-      rm "arduino-nightly-linux64.${downloadFileExtension}"
-      sudo mv "arduino-nightly" "$APPLICATION_FOLDER/arduino-${IDEversion}"
-
+      local downloadVersion="nightly"
     else
-      wget "http://downloads.arduino.cc/arduino-${IDEversion}-linux64.${downloadFileExtension}"
-      tar xf "arduino-${IDEversion}-linux64.${downloadFileExtension}"
-      rm "arduino-${IDEversion}-linux64.${downloadFileExtension}"
-      sudo mv "arduino-${IDEversion}" "$APPLICATION_FOLDER/arduino-${IDEversion}"
+      local downloadVersion="$IDEversion"
     fi
+
+    wget --no-verbose $ARDUINO_CI_SCRIPT_QUIET_OPTION "http://downloads.arduino.cc/arduino-${downloadVersion}-linux64.${downloadFileExtension}"
+    tar --extract --file="arduino-${downloadVersion}-linux64.${downloadFileExtension}"
+    rm $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "arduino-${downloadVersion}-linux64.${downloadFileExtension}"
+    mv $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "arduino-${downloadVersion}" "$ARDUINO_CI_SCRIPT_APPLICATION_FOLDER/arduino-${IDEversion}"
   done
 
-  # Temporarily install the latest IDE version
-  install_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
-  # Create the link that will be used for all IDE installations
-  sudo ln --symbolic "$APPLICATION_FOLDER/arduino/arduino" /usr/local/bin/arduino
+  set_ide_preference "compiler.warning_level=all"
 
-  # Set the preferences
-  # --pref option is only supported by Arduino IDE 1.5.6 and newer
-  local regex="1.5.[0-5]"
-  if ! [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $regex ]]; then
-    # Create the sketchbook folder if it doesn't already exist. The location can't be set in preferences if the folder doesn't exist.
-    create_folder "$SKETCHBOOK_FOLDER"
-
-    # --save-prefs was added in Arduino IDE 1.5.8
-    local regex="1.5.[6-7]"
-    if ! [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $regex ]]; then
-      arduino --pref compiler.warning_level=all --pref sketchbook.path="$SKETCHBOOK_FOLDER" --save-prefs
-    else
-      # Arduino IDE 1.5.6 - 1.5.7 load the GUI if you only set preferences without doing a verify. So I am doing an unnecessary verification just to set the preferences in those versions. Definitely a hack but I prefer to keep the preferences setting code all here instead of cluttering build_sketch and this will pretty much never be used.
-      arduino --pref compiler.warning_level=all --pref sketchbook.path="$SKETCHBOOK_FOLDER" --verify "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino"
-    fi
+  # If a sketchbook location has been defined then set the location in the Arduino IDE preferences
+  if [[ -d "$ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER" ]]; then
+    set_ide_preference "sketchbook.path=$ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER"
   fi
-
-  # Uninstall the IDE
-  uninstall_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
 
   # Return errexit to the default state
   set +o errexit
@@ -277,59 +273,57 @@ function install_ide()
 
 
 # Generate an array of Arduino IDE versions as a subset of the list provided in the base array defined by the start and end versions
-# This function allows the same code to be shared by install_ide and build_sketch. The generated array is "returned" as a global named "$GENERATED_IDE_VERSION_LIST_ARRAY"
+# This function allows the same code to be shared by install_ide and build_sketch. The generated array is "returned" as a global named "$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"
 function generate_ide_version_list_array()
 {
-  enable_verbosity
-
-  local baseIDEversionArray="$1"
+  local -r baseIDEversionArray="$1"
   local startIDEversion="$2"
   local endIDEversion="$3"
 
   # Convert "oldest" or "newest" to actual version numbers
   determine_ide_version_extremes "$baseIDEversionArray"
   if [[ "$startIDEversion" == "oldest" ]]; then
-    local startIDEversion="$DETERMINED_OLDEST_IDE_VERSION"
+    startIDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION"
   elif [[ "$startIDEversion" == "newest" ]]; then
-    local startIDEversion="$DETERMINED_NEWEST_IDE_VERSION"
+    startIDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
   fi
 
   if [[ "$endIDEversion" == "oldest" ]]; then
-    local endIDEversion="$DETERMINED_OLDEST_IDE_VERSION"
+    endIDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION"
   elif [[ "$endIDEversion" == "newest" ]]; then
-    local endIDEversion="$DETERMINED_NEWEST_IDE_VERSION"
+    endIDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
   fi
 
 
   if [[ "$startIDEversion" == "" || "$startIDEversion" == "all" ]]; then
     # Use the full base array
-    GENERATED_IDE_VERSION_LIST_ARRAY="$baseIDEversionArray"
+    ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="$baseIDEversionArray"
 
   else
     # Start the array
-    GENERATED_IDE_VERSION_LIST_ARRAY="$IDE_VERSION_LIST_ARRAY_DECLARATION"'('
+    ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="$ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION"'('
 
-    local regex="\("
-    if [[ "$startIDEversion" =~ $regex ]]; then
+    local -r IDEversionListRegex="\("
+    if [[ "$startIDEversion" =~ $IDEversionListRegex ]]; then
       # IDE versions list was supplied
       # Convert it to a temporary array
-      local suppliedIDEversionListArray="${IDE_VERSION_LIST_ARRAY_DECLARATION}${startIDEversion}"
+      local -r suppliedIDEversionListArray="${ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION}${startIDEversion}"
       eval "$suppliedIDEversionListArray"
       local IDEversion
       for IDEversion in "${IDEversionListArray[@]}"; do
         # Convert any use of "oldest" or "newest" special version names to the actual version number
         if [[ "$IDEversion" == "oldest" ]]; then
-          local IDEversion="$DETERMINED_OLDEST_IDE_VERSION"
+          IDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION"
         elif [[ "$IDEversion" == "newest" ]]; then
-          local IDEversion="$DETERMINED_NEWEST_IDE_VERSION"
+          IDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
         fi
         # Add the version to the array
-        GENERATED_IDE_VERSION_LIST_ARRAY="${GENERATED_IDE_VERSION_LIST_ARRAY} "'"'"$IDEversion"'"'
+        ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="${ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY} "'"'"$IDEversion"'"'
       done
 
     elif [[ "$endIDEversion" == "" ]]; then
       # Only a single version was specified
-      GENERATED_IDE_VERSION_LIST_ARRAY="$GENERATED_IDE_VERSION_LIST_ARRAY"'"'"$startIDEversion"'"'
+      ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"'"'"$startIDEversion"'"'
 
     else
       # A version range was specified
@@ -338,12 +332,12 @@ function generate_ide_version_list_array()
       for IDEversion in "${IDEversionListArray[@]}"; do
         if [[ "$IDEversion" == "$startIDEversion" ]]; then
           # Start of the list reached, set a flag
-          local listIsStarted="true"
+          local -r listIsStarted="true"
         fi
 
         if [[ "$listIsStarted" == "true" ]]; then
           # Add the version to the list
-          GENERATED_IDE_VERSION_LIST_ARRAY="${GENERATED_IDE_VERSION_LIST_ARRAY} "'"'"$IDEversion"'"'
+          ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="${ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY} "'"'"$IDEversion"'"'
         fi
 
         if [[ "$IDEversion" == "$endIDEversion" ]]; then
@@ -354,60 +348,64 @@ function generate_ide_version_list_array()
     fi
 
     # Finish the list
-    GENERATED_IDE_VERSION_LIST_ARRAY="$GENERATED_IDE_VERSION_LIST_ARRAY"')'
+    ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"')'
   fi
-
-  disable_verbosity
 }
 
 
 # Determine the oldest and newest (non-hourly unless hourly is the only version on the list) IDE version in the provided array
-# The determined versions are "returned" by setting the global variables "$DETERMINED_OLDEST_IDE_VERSION" and "$DETERMINED_NEWEST_IDE_VERSION"
+# The determined versions are "returned" by setting the global variables "$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION" and "$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
 function determine_ide_version_extremes()
 {
-  enable_verbosity
-
-  local baseIDEversionArray="$1"
+  local -r baseIDEversionArray="$1"
 
   # Reset the variables from any value they were assigned the last time the function was ran
-  DETERMINED_OLDEST_IDE_VERSION=""
-  DETERMINED_NEWEST_IDE_VERSION=""
+  ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION=""
+  ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION=""
 
   # Determine the oldest and newest (non-hourly) IDE version in the base array
   eval "$baseIDEversionArray"
   local IDEversion
   for IDEversion in "${IDEversionListArray[@]}"; do
-    if [[ "$DETERMINED_OLDEST_IDE_VERSION" == "" ]]; then
-      DETERMINED_OLDEST_IDE_VERSION="$IDEversion"
+    if [[ "$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION" == "" ]]; then
+      ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION="$IDEversion"
     fi
-    if [[ "$DETERMINED_NEWEST_IDE_VERSION" == "" || "$IDEversion" != "hourly" ]]; then
-      DETERMINED_NEWEST_IDE_VERSION="$IDEversion"
+    if [[ "$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION" == "" || "$IDEversion" != "hourly" ]]; then
+      ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION="$IDEversion"
     fi
   done
+}
 
-  disable_verbosity
+
+function set_ide_preference()
+{
+  local -r preferenceString="$1"
+
+  # --pref option is only supported by Arduino IDE 1.5.6 and newer
+  local -r unsupportedPrefOptionVersionsRegex="1.5.[0-5]"
+  if ! [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedPrefOptionVersionsRegex ]]; then
+    install_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
+
+    # --save-prefs was added in Arduino IDE 1.5.8
+    local -r unsupportedSavePrefsOptionVersionsRegex="1.5.[6-7]"
+    if ! [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedSavePrefsOptionVersionsRegex ]]; then
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --pref "$preferenceString" --save-prefs "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+    else
+      # Arduino IDE 1.5.6 - 1.5.7 load the GUI if you only set preferences without doing a verify. So I am doing an unnecessary verification just to set the preferences in those versions. Definitely a hack but I prefer to keep the preferences setting code all here instead of cluttering build_sketch and this will pretty much never be used.
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --pref "$preferenceString" --verify "${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+    fi
+  fi
 }
 
 
 function install_ide_version()
 {
-  enable_verbosity
+  local -r IDEversion="$1"
 
-  local IDEversion="$1"
-  sudo mv "${APPLICATION_FOLDER}/arduino-${IDEversion}" "${APPLICATION_FOLDER}/arduino"
-
-  disable_verbosity
-}
-
-
-function uninstall_ide_version()
-{
-  enable_verbosity
-
-  local IDEversion="$1"
-  sudo mv "${APPLICATION_FOLDER}/arduino" "${APPLICATION_FOLDER}/arduino-${IDEversion}"
-
-  disable_verbosity
+  # Create a symbolic link so that the Arduino IDE can always be referenced from the same path no matter which version is being used.
+  ln --symbolic --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/arduino-${IDEversion}" "${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}"
 }
 
 
@@ -418,41 +416,44 @@ function install_package()
 
   set -o errexit
 
-  local regex="://"
-  if [[ "$1" =~ $regex ]]; then
+  local -r URLregex="://"
+  if [[ "$1" =~ $URLregex ]]; then
     # First argument is a URL, do a manual hardware package installation
     # Note: Assumes the package is in the root of the download and has the correct folder structure (e.g. architecture folder added in Arduino IDE 1.5+)
 
-    local packageURL="$1"
+    local -r packageURL="$1"
 
     # Create the hardware folder if it doesn't exist
-    create_folder "${SKETCHBOOK_FOLDER}/hardware"
+    create_folder "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware"
 
     if [[ "$packageURL" =~ \.git$ ]]; then
       # Clone the repository
-      cd "${SKETCHBOOK_FOLDER}/hardware"
-      git clone "$packageURL"
+      local -r branchName="$2"
 
+      cd "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware"
+
+      if [[ "$branchName" == "" ]]; then
+        git clone --quiet "$packageURL"
+      else
+        git clone --quiet --branch "$branchName" "$packageURL"
+      fi
     else
-      cd "$TEMPORARY_FOLDER"
+      cd "$ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER"
 
       # Clean up the temporary folder
-      rm -f ./*.*
+      rm --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./*.*
 
       # Download the package
-      wget "$packageURL"
+      wget --no-verbose $ARDUINO_CI_SCRIPT_QUIET_OPTION "$packageURL"
 
       # Uncompress the package
-      # This script handles any compressed file type
-      # shellcheck source=/dev/null
-      source "${ARDUINO_CI_SCRIPT_FOLDER}/extract.sh"
       extract ./*.*
 
       # Clean up the temporary folder
-      rm -f ./*.*
+      rm --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./*.*
 
       # Install the package
-      mv ./* "${SKETCHBOOK_FOLDER}/hardware/"
+      mv $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/"
     fi
 
   elif [[ "$1" == "" ]]; then
@@ -460,38 +461,44 @@ function install_package()
     # https://docs.travis-ci.com/user/environment-variables#Global-Variables
     local packageName
     packageName="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 2)"
-    mkdir --parents "${SKETCHBOOK_FOLDER}/hardware/$packageName"
+    mkdir --parents $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/$packageName"
     cd "$TRAVIS_BUILD_DIR"
-    cp --recursive $VERBOSITY_OPTION ./* "${SKETCHBOOK_FOLDER}/hardware/${packageName}"
+    cp --recursive $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/${packageName}"
     # * doesn't copy .travis.yml but that file will be present in the user's installation so it should be there for the tests too
-    cp $VERBOSITY_OPTION "${TRAVIS_BUILD_DIR}/.travis.yml" "${SKETCHBOOK_FOLDER}/hardware/${packageName}"
+    cp $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${TRAVIS_BUILD_DIR}/.travis.yml" "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/${packageName}"
 
   else
     # Install package via Boards Manager
 
-    local packageID="$1"
-    local packageURL="$2"
+    local -r packageID="$1"
+    local -r packageURL="$2"
+
+    # Check if Arduino IDE is installed
+    if [[ "$INSTALLED_IDE_VERSION_LIST_ARRAY" == "" ]]; then
+      echo "ERROR: Installing a hardware package via Boards Manager requires the Arduino IDE to be installed. Please call install_ide before this command."
+      return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    fi
 
     # Check if the newest installed IDE version supports --install-boards
-    local regex1="1.5.[0-9]"
-    local regex2="1.6.[0-3]"
-    if [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $regex1 || "$NEWEST_INSTALLED_IDE_VERSION" =~ $regex2 ]]; then
+    local -r unsupportedInstallBoardsOptionVersionsRange1regex="1.5.[0-9]"
+    local -r unsupportedInstallBoardsOptionVersionsRange2regex="1.6.[0-3]"
+    if [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedInstallBoardsOptionVersionsRange1regex || "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedInstallBoardsOptionVersionsRange2regex ]]; then
       echo "ERROR: --install-boards option is not supported by the newest version of the Arduino IDE you have installed. You must have Arduino IDE 1.6.4 or newer installed to use this function."
-      return 1
+      return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
     else
       # Temporarily install the latest IDE version to use for the package installation
       install_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
 
       # If defined add the boards manager URL to preferences
       if [[ "$packageURL" != "" ]]; then
-        arduino --pref boardsmanager.additional.urls="$packageURL" --save-prefs
+        # shellcheck disable=SC2086
+        eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --pref boardsmanager.additional.urls="$packageURL" --save-prefs "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
       fi
 
       # Install the package
-      arduino --install-boards "$packageID"
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --install-boards "$packageID" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
 
-      # Uninstall the IDE
-      uninstall_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
     fi
   fi
 
@@ -507,42 +514,45 @@ function install_library()
 
   set -o errexit
 
-  local libraryIdentifier="$1"
-  local newFolderName="$2"
+  local -r libraryIdentifier="$1"
 
   # Create the libraries folder if it doesn't already exist
-  create_folder "${SKETCHBOOK_FOLDER}/libraries"
+  create_folder "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries"
 
-  local regex="://"
-  if [[ "$libraryIdentifier" =~ $regex ]]; then
+  local -r URLregex="://"
+  if [[ "$libraryIdentifier" =~ $URLregex ]]; then
     # The argument is a URL
     # Note: this assumes the library is in the root of the file
     if [[ "$libraryIdentifier" =~ \.git$ ]]; then
       # Clone the repository
-      cd "${SKETCHBOOK_FOLDER}/libraries"
-      if [[ "$newFolderName" == "" ]]; then
-        git clone "$libraryIdentifier"
-      else
-        git clone "$libraryIdentifier" "$newFolderName"
-      fi
+      local -r branchName="$2"
+      local -r newFolderName="$3"
 
+      cd "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries"
+
+      if [[ "$branchName" == "" && "$newFolderName" == "" ]]; then
+        git clone --quiet "$libraryIdentifier"
+      elif [[ "$branchName" == "" ]]; then
+        git clone --quiet "$libraryIdentifier" "$newFolderName"
+      elif [[ "$newFolderName" == "" ]]; then
+        git clone --quiet --branch "$branchName" "$libraryIdentifier"
+      else
+        git clone --quiet --branch "$branchName" "$libraryIdentifier" "$newFolderName"
+      fi
     else
       # Assume it's a compressed file
-
+      local -r newFolderName="$2"
       # Download the file to the temporary folder
-      cd "$TEMPORARY_FOLDER"
+      cd "$ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER"
       # Clean up the temporary folder
-      rm -f ./*.*
-      wget "$libraryIdentifier"
+      rm --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./*.*
+      wget --no-verbose $ARDUINO_CI_SCRIPT_QUIET_OPTION "$libraryIdentifier"
 
-      # This script handles any compressed file type
-      # shellcheck source=/dev/null
-      source "${ARDUINO_CI_SCRIPT_FOLDER}/extract.sh"
       extract ./*.*
       # Clean up the temporary folder
-      rm -f ./*.*
+      rm --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./*.*
       # Install the library
-      mv ./* "${SKETCHBOOK_FOLDER}/libraries/${newFolderName}"
+      mv $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/${newFolderName}"
     fi
 
   elif [[ "$libraryIdentifier" == "" ]]; then
@@ -550,31 +560,37 @@ function install_library()
     # https://docs.travis-ci.com/user/environment-variables#Global-Variables
     local libraryName
     libraryName="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 2)"
-    mkdir --parents "${SKETCHBOOK_FOLDER}/libraries/$libraryName"
+    mkdir --parents $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/$libraryName"
     cd "$TRAVIS_BUILD_DIR"
-    cp --recursive $VERBOSITY_OPTION ./* "${SKETCHBOOK_FOLDER}/libraries/${libraryName}"
+    cp --recursive $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/${libraryName}"
     # * doesn't copy .travis.yml but that file will be present in the user's installation so it should be there for the tests too
-    cp $VERBOSITY_OPTION "${TRAVIS_BUILD_DIR}/.travis.yml" "${SKETCHBOOK_FOLDER}/libraries/${libraryName}"
+    cp $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${TRAVIS_BUILD_DIR}/.travis.yml" "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/${libraryName}"
 
   else
     # Install a library that is part of the Library Manager index
+
+    # Check if Arduino IDE is installed
+    if [[ "$INSTALLED_IDE_VERSION_LIST_ARRAY" == "" ]]; then
+      echo "ERROR: Installing a library via Library Manager requires the Arduino IDE to be installed. Please call install_ide before this command."
+      return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    fi
+
     # Check if the newest installed IDE version supports --install-library
-    local regex1="1.5.[0-9]"
-    local regex2="1.6.[0-3]"
-    if [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $regex1 || "$NEWEST_INSTALLED_IDE_VERSION" =~ $regex2 ]]; then
+    local -r unsupportedInstallLibraryOptionVersionsRange1regex="1.5.[0-9]"
+    local -r unsupportedInstallLibraryOptionVersionsRange2regex="1.6.[0-3]"
+    if [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedInstallLibraryOptionVersionsRange1regex || "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedInstallLibraryOptionVersionsRange2regex ]]; then
       echo "ERROR: --install-library option is not supported by the newest version of the Arduino IDE you have installed. You must have Arduino IDE 1.6.4 or newer installed to use this function."
-      return 1
+      return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
     else
-      local libraryName="$1"
+      local -r libraryName="$1"
 
       # Temporarily install the latest IDE version to use for the library installation
       install_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
 
        # Install the library
-      arduino --install-library "$libraryName"
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --install-library "$libraryName" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
 
-      # Uninstall the IDE
-      uninstall_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
     fi
   fi
 
@@ -584,15 +600,74 @@ function install_library()
 }
 
 
+# Extract common file formats
+# https://github.com/xvoland/Extract
+function extract
+{
+  if [ -z "$1" ]; then
+    # display usage if no parameters given
+    echo "Usage: extract <path/file_name>.<zip|rar|bz2|gz|tar|tbz2|tgz|Z|7z|xz|ex|tar.bz2|tar.gz|tar.xz>"
+    echo "       extract <path/file_name_1.ext> [path/file_name_2.ext] [path/file_name_3.ext]"
+    return "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  else
+    local filename
+    for filename in "$@"
+    do
+      if [ -f "$filename" ]; then
+        case "${filename%,}" in
+          *.tar.bz2|*.tar.gz|*.tar.xz|*.tbz2|*.tgz|*.txz|*.tar)
+            tar --extract --file="$filename"
+          ;;
+          *.lzma)
+            unlzma $ARDUINO_CI_SCRIPT_QUIET_OPTION ./"$filename"
+          ;;
+          *.bz2)
+            bunzip2 $ARDUINO_CI_SCRIPT_QUIET_OPTION ./"$filename"
+          ;;
+          *.rar)
+            eval unrar x -ad ./"$filename" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+          ;;
+          *.gz)
+            gunzip ./"$filename"
+          ;;
+          *.zip)
+            unzip -qq ./"$filename"
+          ;;
+          *.z)
+            eval uncompress ./"$filename" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+          ;;
+          *.7z|*.arj|*.cab|*.chm|*.deb|*.dmg|*.iso|*.lzh|*.msi|*.rpm|*.udf|*.wim|*.xar)
+            7z x ./"$filename"
+          ;;
+          *.xz)
+            unxz $ARDUINO_CI_SCRIPT_QUIET_OPTION ./"$filename"
+          ;;
+          *.exe)
+            cabextract $ARDUINO_CI_SCRIPT_QUIET_OPTION ./"$filename"
+          ;;
+          *)
+            echo "extract: '$filename' - unknown archive method"
+            return "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+          ;;
+        esac
+      else
+        echo "extract: '$filename' - file does not exist"
+        return "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+      fi
+    done
+  fi
+}
+
+
 function set_verbose_output_during_compilation()
 {
   enable_verbosity
 
-  local verboseOutputDuringCompilation="$1"
+  local -r verboseOutputDuringCompilation="$1"
   if [[ "$verboseOutputDuringCompilation" == "true" ]]; then
-    VERBOSE_BUILD="--verbose"
+    ARDUINO_CI_SCRIPT_DETERMINED_VERBOSE_BUILD="--verbose"
   else
-    VERBOSE_BUILD=""
+    ARDUINO_CI_SCRIPT_DETERMINED_VERBOSE_BUILD=""
   fi
 
   disable_verbosity
@@ -604,18 +679,23 @@ function build_sketch()
 {
   enable_verbosity
 
-  local sketchPath="$1"
-  local boardID="$2"
-  local allowFail="$3"
-  local startIDEversion="$4"
-  local endIDEversion="$5"
+  local -r sketchPath="$1"
+  local -r boardID="$2"
+  local -r allowFail="$3"
+  local -r startIDEversion="$4"
+  local -r endIDEversion="$5"
 
-  # Set default value for buildSketchExitCode
-  local buildSketchExitCode=0
+  # Set default value for buildSketchExitStatus
+  local buildSketchExitStatus="$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS"
 
   generate_ide_version_list_array "$INSTALLED_IDE_VERSION_LIST_ARRAY" "$startIDEversion" "$endIDEversion"
 
-  eval "$GENERATED_IDE_VERSION_LIST_ARRAY"
+  if [[ "$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY" == "$ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION"'()' ]]; then
+    echo "ERROR: The IDE version(s) specified are not installed"
+    return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  fi
+
+  eval "$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"
   local IDEversion
   for IDEversion in "${IDEversionListArray[@]}"; do
     # Install the IDE
@@ -624,11 +704,12 @@ function build_sketch()
 
     # The package_index files installed by some versions of the IDE (1.6.5, 1.6.5) can cause compilation to fail for other versions (1.6.5-r4, 1.6.5-r5). Attempting to install a dummy package ensures that the correct version of those files will be installed before the sketch verification.
     # Check if the newest installed IDE version supports --install-boards
-    local regex1="1.5.[0-9]"
-    local regex2="1.6.[0-3]"
-    if ! [[ "$IDEversion" =~ $regex1 || "$IDEversion" =~ $regex2 ]]; then
-      eval arduino --install-boards arduino:dummy "$VERBOSITY_REDIRECT"
-      if [[ "$SCRIPT_VERBOSITY_LEVEL" -gt 1 ]]; then
+    local unsupportedInstallBoardsOptionVersionsRange1regex="1.5.[0-9]"
+    local unsupportedInstallBoardsOptionVersionsRange2regex="1.6.[0-3]"
+    if ! [[ "$IDEversion" =~ $unsupportedInstallBoardsOptionVersionsRange1regex || "$IDEversion" =~ $unsupportedInstallBoardsOptionVersionsRange2regex ]]; then
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --install-boards arduino:dummy "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+      if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -gt 1 ]]; then
         # The warning is printed to stdout
         echo "NOTE: The warning above \"Selected board is not available\" is caused intentionally and does not indicate a problem."
       fi
@@ -636,12 +717,16 @@ function build_sketch()
 
     if [[ "$sketchPath" =~ \.ino$ || "$sketchPath" =~ \.pde$ ]]; then
       # A sketch was specified
-      if ! build_this_sketch "$sketchPath" "$boardID" "$IDEversion" "$allowFail"; then
-        # build_this_sketch returned a non-zero exit code
-        buildSketchExitCode=1
+      if ! [[ -f "$sketchPath" ]]; then
+        echo "ERROR: Specified sketch: $sketchPath doesn't exist"
+        buildSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+      elif ! build_this_sketch "$sketchPath" "$boardID" "$IDEversion" "$allowFail"; then
+        # build_this_sketch returned a non-zero exit status
+        buildSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
       fi
     else
       # Search for all sketches in the path and put them in an array
+      local sketchFound="false"
       # https://github.com/koalaman/shellcheck/wiki/SC2207
       declare -a sketches
       mapfile -t sketches < <(find "$sketchPath" -name "*.pde" -o -name "*.ino")
@@ -655,20 +740,24 @@ function build_sketch()
         local sketchNameWithoutPathWithoutExtension
         sketchNameWithoutPathWithoutExtension="${sketchNameWithoutPathWithExtension%.*}"
         if [[ "$sketchFolder" == "$sketchNameWithoutPathWithoutExtension" ]]; then
+          sketchFound="true"
           if ! build_this_sketch "$sketchName" "$boardID" "$IDEversion" "$allowFail"; then
-            # build_this_sketch returned a non-zero exit code
-            buildSketchExitCode=1;
+            # build_this_sketch returned a non-zero exit status
+            buildSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
           fi
         fi
       done
+
+      if [[ "$sketchFound" == "false" ]]; then
+        echo "ERROR: No valid sketches were found in the specified path"
+        buildSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+      fi
     fi
-    # Uninstall the IDE
-    uninstall_ide_version "$IDEversion"
   done
 
   disable_verbosity
 
-  return $buildSketchExitCode
+  return $buildSketchExitStatus
 }
 
 
@@ -677,91 +766,190 @@ function build_this_sketch()
   # Fold this section of output in the Travis CI build log to make it easier to read
   echo -e "travis_fold:start:build_sketch"
 
-  enable_verbosity
-
-  local sketchName="$1"
-  local boardID="$2"
-  local IDEversion="$3"
-  local allowFail="$4"
+  local -r sketchName="$1"
+  local -r boardID="$2"
+  local -r IDEversion="$3"
+  local -r allowFail="$4"
 
   # Produce a useful label for the fold in the Travis log for this function call
   echo "build_sketch $sketchName $boardID $IDEversion $allowFail"
 
   # Arduino IDE 1.8.0 and 1.8.1 fail to verify a sketch if the absolute path to it is not specified
   # http://stackoverflow.com/a/3915420/7059512
-  local sketchName
-  sketchName="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+  local absoluteSketchName
+  absoluteSketchName="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 
-  # Set default value of buildThisSketchExitCode
-  local buildThisSketchExitCode=0
-
-  # Define a dummy value for arduinoExitCode so that the while loop will run at least once
-  local arduinoExitCode=255
-  # Retry the verification if arduino returns an exit code that indicates there may have been a temporary error not caused by a bug in the sketch or the arduino command
-  while [[ $arduinoExitCode -gt $HIGHEST_ACCEPTABLE_ARDUINO_EXIT_CODE && $verifyCount -le $SKETCH_VERIFY_RETRIES ]]; do
+  # Define a dummy value for arduinoExitStatus so that the while loop will run at least once
+  local arduinoExitStatus=255
+  # Retry the verification if arduino returns an exit status that indicates there may have been a temporary error not caused by a bug in the sketch or the arduino command
+  while [[ $arduinoExitStatus -gt $ARDUINO_CI_SCRIPT_HIGHEST_ACCEPTABLE_ARDUINO_EXIT_STATUS && $verifyCount -le $ARDUINO_CI_SCRIPT_SKETCH_VERIFY_RETRIES ]]; do
     # Verify the sketch
-    arduino $VERBOSE_BUILD --verify "$sketchName" --board "$boardID" 2>&1 | tee "$VERIFICATION_OUTPUT_FILENAME"; local arduinoExitCode="${PIPESTATUS[0]}"
+    # shellcheck disable=SC2086
+    "${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino" $ARDUINO_CI_SCRIPT_DETERMINED_VERBOSE_BUILD --verify "$absoluteSketchName" --board "$boardID" 2>&1 | tee "$ARDUINO_CI_SCRIPT_VERIFICATION_OUTPUT_FILENAME"; local arduinoExitStatus="${PIPESTATUS[0]}"
     local verifyCount=$((verifyCount + 1))
   done
 
-  # If the sketch build failed and failure is not allowed for this test then fail the Travis build after completing all sketch builds
-  if [[ "$arduinoExitCode" != "0" ]]; then
-    if [[ "$allowFail" != "true" ]]; then
-      buildThisSketchExitCode=1
-    fi
+  if [[ "$arduinoExitStatus" != "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]]; then
+    # Sketch verification failed
+    local buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
   else
+    # Sketch verification succeeded
+    local buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS"
+
     # Parse through the output from the sketch verification to count warnings and determine the compile size
     local warningCount=0
+    local boardIssueCount=0
+    local libraryIssueCount=0
     while read -r outputFileLine; do
       # Determine program storage memory usage
-      local regex="Sketch uses ([0-9,]+) *"
-      if [[ "$outputFileLine" =~ $regex ]] > /dev/null; then
-        local programStorage=${BASH_REMATCH[1]}
+      local programStorageRegex="Sketch uses ([0-9,]+) *"
+      if [[ "$outputFileLine" =~ $programStorageRegex ]] > /dev/null; then
+        local -r programStorageWithComma=${BASH_REMATCH[1]}
       fi
 
       # Determine dynamic memory usage
-      local regex="Global variables use ([0-9,]+) *"
-      if [[ "$outputFileLine" =~ $regex ]] > /dev/null; then
-        local dynamicMemory=${BASH_REMATCH[1]}
+      local dynamicMemoryRegex="Global variables use ([0-9,]+) *"
+      if [[ "$outputFileLine" =~ $dynamicMemoryRegex ]] > /dev/null; then
+        local -r dynamicMemoryWithComma=${BASH_REMATCH[1]}
       fi
 
       # Increment warning count
-      local regex="warning: "
-      if [[ "$outputFileLine" =~ $regex ]] > /dev/null; then
-        local warningCount=$((warningCount + 1))
+      local warningRegex="warning: "
+      if [[ "$outputFileLine" =~ $warningRegex ]] > /dev/null; then
+        warningCount=$((warningCount + 1))
       fi
 
-      # Check for missing bootloader
-      if [[ "$TEST_BOARD" == "true" ]]; then
-        local regex="Bootloader file specified but missing: "
-        if [[ "$outputFileLine" =~ $regex ]] > /dev/null; then
-          local boardError="missing bootloader"
-          if [[ "$allowFail" != "true" ]]; then
-            buildThisSketchExitCode=1
-          fi
-        fi
+      # Check for board issues
+      local bootloaderMissingRegex="Bootloader file specified but missing: "
+      if [[ "$outputFileLine" =~ $bootloaderMissingRegex ]] > /dev/null; then
+        local boardIssue="missing bootloader"
+        boardIssueCount=$((boardIssueCount + 1))
       fi
-    done < "$VERIFICATION_OUTPUT_FILENAME"
 
-    rm "$VERIFICATION_OUTPUT_FILENAME"
+      local boardsDotTxtMissingRegex="Could not find boards.txt"
+      if [[ "$outputFileLine" =~ $boardsDotTxtMissingRegex ]] > /dev/null; then
+        local boardIssue="Could not find boards.txt"
+        boardIssueCount=$((boardIssueCount + 1))
+      fi
+
+      local buildDotBoardNotDefinedRegex="doesn't define a 'build.board' preference"
+      if [[ "$outputFileLine" =~ $buildDotBoardNotDefinedRegex ]] > /dev/null; then
+        local boardIssue="doesn't define a 'build.board' preference"
+        boardIssueCount=$((boardIssueCount + 1))
+      fi
+
+      # Check for library issues
+      # This is the generic "invalid library" warning that doesn't specify the reason
+      local invalidLibrarRegex1="Invalid library found in"
+      local invalidLibrarRegex2="from library$"
+      if [[ "$outputFileLine" =~ $invalidLibrarRegex1 ]] && ! [[ "$outputFileLine" =~ $invalidLibrarRegex2 ]] > /dev/null; then
+        local libraryIssue="Invalid library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingNameRegex="Invalid library found in .* Missing 'name' from library"
+      if [[ "$outputFileLine" =~ $missingNameRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'name' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingVersionRegex="Invalid library found in .* Missing 'version' from library"
+      if [[ "$outputFileLine" =~ $missingVersionRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'version' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingAuthorRegex="Invalid library found in .* Missing 'author' from library"
+      if [[ "$outputFileLine" =~ $missingAuthorRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'author' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingMaintainerRegex="Invalid library found in .* Missing 'maintainer' from library"
+      if [[ "$outputFileLine" =~ $missingMaintainerRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'maintainer' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingSentenceRegex="Invalid library found in .* Missing 'sentence' from library"
+      if [[ "$outputFileLine" =~ $missingSentenceRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'sentence' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingParagraphRegex="Invalid library found in .* Missing 'paragraph' from library"
+      if [[ "$outputFileLine" =~ $missingParagraphRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'paragraph' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingURLregex="Invalid library found in .* Missing 'url' from library"
+      if [[ "$outputFileLine" =~ $missingURLregex ]] > /dev/null; then
+        local libraryIssue="Missing 'url' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local invalidVersionRegex="Invalid version found:"
+      if [[ "$outputFileLine" =~ $invalidVersionRegex ]] > /dev/null; then
+        local libraryIssue="Invalid version found:"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local invalidCategoryRegex="is not valid. Setting to 'Uncategorized'"
+      if [[ "$outputFileLine" =~ $invalidCategoryRegex ]] > /dev/null; then
+        local libraryIssue="Invalid category"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local spuriousFolderRegex="WARNING: Spurious"
+      if [[ "$outputFileLine" =~ $spuriousFolderRegex ]] > /dev/null; then
+        local libraryIssue="Spurious folder"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+    done < "$ARDUINO_CI_SCRIPT_VERIFICATION_OUTPUT_FILENAME"
+
+    rm $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "$ARDUINO_CI_SCRIPT_VERIFICATION_OUTPUT_FILENAME"
 
     # Remove the stupid comma from the memory values if present
-    local programStorage=${programStorage//,}
-    local dynamicMemory=${dynamicMemory//,}
+    local -r programStorage=${programStorageWithComma//,}
+    local -r dynamicMemory=${dynamicMemoryWithComma//,}
+
+    if [[ "$boardIssue" != "" && "$ARDUINO_CI_SCRIPT_TEST_BOARD" == "true" ]]; then
+      # There was a board issue and board testing is enabled so fail the build
+      local buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    fi
+
+    if [[ "$libraryIssue" != "" && "$ARDUINO_CI_SCRIPT_TEST_LIBRARY" == "true" ]]; then
+      # There was a library issue and library testing is enabled so fail the build
+      local buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    fi
   fi
 
   # Add the build data to the report file
-  echo "$(date -u "+%Y-%m-%d %H:%M:%S")"$'\t'"$TRAVIS_BUILD_NUMBER"$'\t'"$TRAVIS_JOB_NUMBER"$'\t'"https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}"$'\t'"$TRAVIS_EVENT_TYPE"$'\t'"$TRAVIS_ALLOW_FAILURE"$'\t'"$TRAVIS_PULL_REQUEST"$'\t'"$TRAVIS_BRANCH"$'\t'"$TRAVIS_COMMIT"$'\t'"$TRAVIS_COMMIT_RANGE"$'\t'"${TRAVIS_COMMIT_MESSAGE%%$'\n'*}"$'\t'"$sketchName"$'\t'"$boardID"$'\t'"$IDEversion"$'\t'"$programStorage"$'\t'"$dynamicMemory"$'\t'"$warningCount"$'\t'"$allowFail"$'\t'"$arduinoExitCode"$'\t'"$boardError"$'\r' >> "$REPORT_FILE_PATH"
+  echo "$(date -u "+%Y-%m-%d %H:%M:%S")"$'\t'"$TRAVIS_BUILD_NUMBER"$'\t'"$TRAVIS_JOB_NUMBER"$'\t'"https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}"$'\t'"$TRAVIS_EVENT_TYPE"$'\t'"$TRAVIS_ALLOW_FAILURE"$'\t'"$TRAVIS_PULL_REQUEST"$'\t'"$TRAVIS_BRANCH"$'\t'"$TRAVIS_COMMIT"$'\t'"$TRAVIS_COMMIT_RANGE"$'\t'"${TRAVIS_COMMIT_MESSAGE%%$'\n'*}"$'\t'"$sketchName"$'\t'"$boardID"$'\t'"$IDEversion"$'\t'"$programStorage"$'\t'"$dynamicMemory"$'\t'"$warningCount"$'\t'"$allowFail"$'\t'"$arduinoExitStatus"$'\t'"$boardIssueCount"$'\t'"$boardIssue"$'\t'"$libraryIssueCount"$'\t'"$libraryIssue"$'\r' >> "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH"
+
+  # Adjust the exit status according to the allowFail setting
+  if [[ "$buildThisSketchExitStatus" == "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS" && ("$allowFail" == "true" || "$allowFail" == "require") ]]; then
+    buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS"
+  elif [[ "$buildThisSketchExitStatus" == "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" && "$allowFail" == "require" ]]; then
+    buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  fi
+
+  if [[ "$buildThisSketchExitStatus" != "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]]; then
+    ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT=$((ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT + 1))
+  fi
+  ARDUINO_CI_SCRIPT_TOTAL_WARNING_COUNT=$((ARDUINO_CI_SCRIPT_TOTAL_WARNING_COUNT + warningCount + 0))
+  ARDUINO_CI_SCRIPT_TOTAL_BOARD_ISSUE_COUNT=$((ARDUINO_CI_SCRIPT_TOTAL_BOARD_ISSUE_COUNT + boardIssueCount + 0))
+  ARDUINO_CI_SCRIPT_TOTAL_LIBRARY_ISSUE_COUNT=$((ARDUINO_CI_SCRIPT_TOTAL_LIBRARY_ISSUE_COUNT + libraryIssueCount + 0))
 
   # End the folded section of the Travis CI build log
   echo -e "travis_fold:end:build_sketch"
   # Add a useful message to the Travis CI build log
 
-  disable_verbosity
+  echo "arduino Exit Status: ${arduinoExitStatus}, Allow Failure: ${allowFail}, # Warnings: ${warningCount}, # Board Issues: ${boardIssueCount}, # Library Issues: ${libraryIssueCount}"
 
-  echo "arduino exit code: $arduinoExitCode"
-
-  return $buildThisSketchExitCode
+  return $buildThisSketchExitStatus
 }
 
 
@@ -770,9 +958,14 @@ function display_report()
 {
   enable_verbosity
 
-  if [ -e "$REPORT_FILE_PATH" ]; then
+  if [ -e "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" ]; then
     echo -e "\n\n\n**************Begin Report**************\n\n\n"
-    cat "$REPORT_FILE_PATH"
+    cat "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH"
+    echo -e "\n\n"
+    echo "Total failed sketch builds: $ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT"
+    echo "Total warnings: $ARDUINO_CI_SCRIPT_TOTAL_WARNING_COUNT"
+    echo "Total board issues: $ARDUINO_CI_SCRIPT_TOTAL_BOARD_ISSUE_COUNT"
+    echo "Total library issues: $ARDUINO_CI_SCRIPT_TOTAL_LIBRARY_ISSUE_COUNT"
     echo -e "\n\n"
   else
     echo "No report file available for this job"
@@ -787,48 +980,48 @@ function publish_report_to_repository()
 {
   enable_verbosity
 
-  local token="$1"
-  local repositoryURL="$2"
-  local reportBranch="$3"
-  local reportFolder="$4"
-  local doLinkComment="$5"
+  local -r token="$1"
+  local -r repositoryURL="$2"
+  local -r reportBranch="$3"
+  local -r reportFolder="$4"
+  local -r doLinkComment="$5"
 
   if [[ "$token" != "" ]] && [[ "$repositoryURL" != "" ]] && [[ "$reportBranch" != "" ]]; then
-    if [ -e "$REPORT_FILE_PATH" ]; then
+    if [ -e "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" ]; then
       # Location is a repository
-      git clone $VERBOSITY_OPTION --branch "$reportBranch" "$repositoryURL" "${HOME}/report-repository"; local gitCloneExitCode="${PIPESTATUS[0]}"
-      if [[ "$gitCloneExitCode" == 0 ]]; then
+      if git clone --quiet --branch "$reportBranch" "$repositoryURL" "${HOME}/report-repository"; then
         # Clone was successful
         create_folder "${HOME}/report-repository/${reportFolder}"
-        cp $VERBOSITY_OPTION "$REPORT_FILE_PATH" "${HOME}/report-repository/${reportFolder}"
+        cp $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" "${HOME}/report-repository/${reportFolder}"
         cd "${HOME}/report-repository"
-        git add $VERBOSITY_OPTION "${HOME}/report-repository/${reportFolder}/${REPORT_FILENAME}"
+        git add $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${HOME}/report-repository/${reportFolder}/${ARDUINO_CI_SCRIPT_REPORT_FILENAME}"
         git config user.email "arduino-ci-script@nospam.me"
         git config user.name "arduino-ci-script-bot"
         # Only pushes the current branch to the corresponding remote branch that 'git pull' uses to update the current branch.
         git config push.default simple
         if [[ "$TRAVIS_TEST_RESULT" != "0" ]]; then
-          local jobSuccessMessage="FAILED"
+          local -r jobSuccessMessage="FAILED"
         else
-          local jobSuccessMessage="SUCCESSFUL"
+          local -r jobSuccessMessage="SUCCESSFUL"
         fi
         # Do a pull now in case another job has finished about the same time and pushed a report after the clone happened, which would otherwise cause the push to fail. This is the last chance to pull without having to deal with a merge or rebase.
-        git pull
-        git commit $VERBOSITY_OPTION --message="Add Travis CI job ${TRAVIS_JOB_NUMBER} report (${jobSuccessMessage})" --message="Job log: https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}" --message="Commit: https://github.com/${TRAVIS_REPO_SLUG}/commit/${TRAVIS_COMMIT}" --message="$TRAVIS_COMMIT_MESSAGE" --message="[skip ci]"
-        local gitPushExitCode="1"
+        git pull $ARDUINO_CI_SCRIPT_QUIET_OPTION
+        git commit $ARDUINO_CI_SCRIPT_QUIET_OPTION $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION --message="Add Travis CI job ${TRAVIS_JOB_NUMBER} report (${jobSuccessMessage})" --message="Total failed sketch builds: $ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT" --message="Total warnings: $ARDUINO_CI_SCRIPT_TOTAL_WARNING_COUNT" --message="Total board issues: $ARDUINO_CI_SCRIPT_TOTAL_BOARD_ISSUE_COUNT" --message="Total library issues: $ARDUINO_CI_SCRIPT_TOTAL_LIBRARY_ISSUE_COUNT" --message="Job log: https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}" --message="Commit: https://github.com/${TRAVIS_REPO_SLUG}/commit/${TRAVIS_COMMIT}" --message="$TRAVIS_COMMIT_MESSAGE" --message="[skip ci]"
+        local gitPushExitStatus="1"
         local pushCount=0
-        while [[ "$gitPushExitCode" != "0" && $pushCount -le $REPORT_PUSH_RETRIES ]]; do
+        while [[ "$gitPushExitStatus" != "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" && $pushCount -le $ARDUINO_CI_SCRIPT_REPORT_PUSH_RETRIES ]]; do
           pushCount=$((pushCount + 1))
           # Do a pull now in case another job has finished about the same time and pushed a report since the last pull. This would require a merge or rebase. Rebase should be safe since the commits will be separate files.
-          git pull --rebase
-          git push $VERBOSITY_OPTION "https://${token}@${repositoryURL#*//}"; local gitPushExitCode="${PIPESTATUS[0]}"
+          git pull $ARDUINO_CI_SCRIPT_QUIET_OPTION --rebase
+          git push $ARDUINO_CI_SCRIPT_QUIET_OPTION $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "https://${token}@${repositoryURL#*//}"
+          gitPushExitStatus="$?"
         done
-        rm $VERBOSITY_OPTION --recursive --force "${HOME}/report-repository"
-        if [[ "$gitPushExitCode" == "0" ]]; then
+        rm --recursive --force "${HOME}/report-repository"
+        if [[ "$gitPushExitStatus" == "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]]; then
           if [[ "$doLinkComment" == "true" ]]; then
             # Only comment if it's job 1
-            local regex="\.1$"
-            if [[ "$TRAVIS_JOB_NUMBER" =~ $regex ]]; then
+            local -r firstJobRegex="\.1$"
+            if [[ "$TRAVIS_JOB_NUMBER" =~ $firstJobRegex ]]; then
               local reportURL
               reportURL="${repositoryURL%.*}/tree/${reportBranch}/${reportFolder}"
               comment_report_link "$token" "$reportURL"
@@ -836,18 +1029,26 @@ function publish_report_to_repository()
           fi
         else
           echo "ERROR: Failed to push to remote branch."
-          return 3
+          return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
         fi
       else
         echo "ERROR: Failed to clone branch ${reportBranch} of repository URL ${repositoryURL}. Do they exist?"
-        return 2
+        return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
       fi
     else
       echo "No report file available for this job"
     fi
   else
-    echo "Publishing report failed. GitHub token, repository URL, and repository branch must be defined to use this function. See https://github.com/per1234/arduino-ci-script#publishing-job-reports for instructions."
-    return 1
+    if [[ "$token" == "" ]]; then
+      echo "ERROR: GitHub token not specified. Failed to publish build report. See https://github.com/per1234/arduino-ci-script#publishing-job-reports for instructions."
+    fi
+    if [[ "$repositoryURL" == "" ]]; then
+      echo "ERROR: Repository URL not specified. Failed to publish build report."
+    fi
+    if [[ "$reportBranch" == "" ]]; then
+      echo "ERROR: Repository branch not specified. Failed to publish build report."
+    fi
+    return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
   fi
 
   disable_verbosity
@@ -859,12 +1060,12 @@ function publish_report_to_gist()
 {
   enable_verbosity
 
-  local token="$1"
-  local gistURL="$2"
-  local doLinkComment="$3"
+  local -r token="$1"
+  local -r gistURL="$2"
+  local -r doLinkComment="$3"
 
   if [[ "$token" != "" ]] && [[ "$gistURL" != "" ]]; then
-    if [ -e "$REPORT_FILE_PATH" ]; then
+    if [ -e "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" ]; then
       # Get the gist ID from the gist URL
       local gistID
       gistID="$(echo "$gistURL" | rev | cut -d'/' -f 1 | rev)"
@@ -873,18 +1074,18 @@ function publish_report_to_gist()
       # Sanitize the report file content so it can be sent via a POST request without breaking the JSON
       # Remove \r (from Windows end-of-lines), replace tabs by \t, replace " by \", replace EOL by \n
       local reportContent
-      reportContent=$(sed -e 's/\r//' -e's/\t/\\t/g' -e 's/"/\\"/g' "$REPORT_FILE_PATH" | awk '{ printf($0 "\\n") }')
+      reportContent=$(sed -e 's/\r//' -e's/\t/\\t/g' -e 's/"/\\"/g' "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" | awk '{ printf($0 "\\n") }')
 
       # Upload the report to the Gist. I have to use the here document to avoid the "Argument list too long" error from curl with long reports. Redirect output to dev/null because it dumps the whole gist to the log
-      eval curl --header "\"Authorization: token ${token}\"" --data @- "\"https://api.github.com/gists/${gistID}\"" <<curlDataHere "$VERBOSITY_REDIRECT"
-{"files":{"${REPORT_FILENAME}":{"content": "${reportContent}"}}}
+      eval curl --header "\"Authorization: token ${token}\"" --data @- "\"https://api.github.com/gists/${gistID}\"" <<curlDataHere "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+{"files":{"${ARDUINO_CI_SCRIPT_REPORT_FILENAME}":{"content": "${reportContent}"}}}
 curlDataHere
 
       if [[ "$doLinkComment" == "true" ]]; then
         # Only comment if it's job 1
-        local regex="\.1$"
-        if [[ "$TRAVIS_JOB_NUMBER" =~ $regex ]]; then
-          local reportURL="${gistURL}#file-${REPORT_FILENAME//./-}"
+        local -r firstJobRegex="\.1$"
+        if [[ "$TRAVIS_JOB_NUMBER" =~ $firstJobRegex ]]; then
+          local reportURL="${gistURL}#file-${ARDUINO_CI_SCRIPT_REPORT_FILENAME//./-}"
           comment_report_link "$token" "$reportURL"
         fi
       fi
@@ -892,8 +1093,13 @@ curlDataHere
       echo "No report file available for this job"
     fi
   else
-    echo "Publishing report failed. GitHub token and gist URL must be defined in your Travis CI settings for this repository in order to use this function. See https://github.com/per1234/arduino-ci-script#publishing-job-reports for instructions."
-    return 1
+    if [[ "$token" == "" ]]; then
+      echo "ERROR: GitHub token not specified. Failed to publish build report. See https://github.com/per1234/arduino-ci-script#publishing-job-reports for instructions."
+    fi
+    if [[ "$gistURL" == "" ]]; then
+      echo "ERROR: Gist URL not specified. Failed to publish build report. See https://github.com/per1234/arduino-ci-script#publishing-job-reports for instructions."
+    fi
+    return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
   fi
 
   disable_verbosity
@@ -903,14 +1109,13 @@ curlDataHere
 # Leave a comment on the commit with a link to the report
 function comment_report_link()
 {
-  enable_verbosity
+  local -r token="$1"
+  local -r reportURL="$2"
 
-  local token="$1"
-  local reportURL="$2"
-
-  eval curl --header "\"Authorization: token ${token}\"" --data \"{'\"'body'\"':'\"'Once completed, the job reports for Travis CI [build ${TRAVIS_BUILD_NUMBER}]\(https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_BUILD_ID}\) will be found at:\\n${reportURL}'\"'}\" "\"https://api.github.com/repos/${TRAVIS_REPO_SLUG}/commits/${TRAVIS_COMMIT}/comments\"" "$VERBOSITY_REDIRECT"
-
-  disable_verbosity
+  eval curl $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION --header "\"Authorization: token ${token}\"" --data \"{'\"'body'\"':'\"'Once completed, the job reports for Travis CI [build ${TRAVIS_BUILD_NUMBER}]\(https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_BUILD_ID}\) will be found at:\\n${reportURL}'\"'}\" "\"https://api.github.com/repos/${TRAVIS_REPO_SLUG}/commits/${TRAVIS_COMMIT}/comments\"" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+  if [[ $? -ne $ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS ]]; then
+    echo "ERROR: Failed to comment link to published report location"
+  fi
 }
 
 
@@ -919,3 +1124,25 @@ function check_success()
 {
   echo "The check_success function is no longer necessary and has been deprecated"
 }
+
+
+# Set default verbosity (must be called after the function definitions
+set_script_verbosity 0
+
+
+# Create the temporary folder
+create_folder "$ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER"
+
+# Create the report folder
+create_folder "$ARDUINO_CI_SCRIPT_REPORT_FOLDER"
+
+
+# Add column names to report
+echo "Build Timestamp (UTC)"$'\t'"Build"$'\t'"Job"$'\t'"Job URL"$'\t'"Build Trigger"$'\t'"Allow Job Failure"$'\t'"PR#"$'\t'"Branch"$'\t'"Commit"$'\t'"Commit Range"$'\t'"Commit Message"$'\t'"Sketch Filename"$'\t'"Board ID"$'\t'"IDE Version"$'\t'"Program Storage (bytes)"$'\t'"Dynamic Memory (bytes)"$'\t'"# Warnings"$'\t'"Allow Failure"$'\t'"Exit Status"$'\t'"# Board Issues"$'\t'"Board Issue"$'\t'"# Library Issues"$'\t'"Library Issue"$'\r' > "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH"
+
+
+# Start the virtual display required by the Arduino IDE CLI: https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#bugs
+# based on https://learn.adafruit.com/continuous-integration-arduino-and-you/testing-your-project
+/sbin/start-stop-daemon --start $ARDUINO_CI_SCRIPT_QUIET_OPTION $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
+sleep 3
+export DISPLAY=:1.0


### PR DESCRIPTION
https://github.com/per1234/arduino-ci-script/tree/1.0.0

- Add testing for Arduino IDE 1.8.3
- Improve efficiency of the build process
- Reduce unnecessary log verbosity
- Detect more hardware definition issues
- Detect library issues that don't affect compilation
- Various improvements of reliability and error handling