### PR TITLE
Update arduino-ci-script subtree to 1.0.1 tag and improve Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # This file is used to configure the Travis CI tests of MCUdude_corefiles
 
+# Although sudo is no longer required by arduino-ci-script since the 1.0.0 release, for some reason setting "sudo: false" causes the Travis CI build time to significantly increase so this setting is left as "sudo: required"
 sudo: required
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # This file is used to configure the Travis CI tests of MCUdude_corefiles
 
-language: bash
 sudo: required
 
 

--- a/travis-ci/arduino-ci-script/.travis.yml
+++ b/travis-ci/arduino-ci-script/.travis.yml
@@ -13,7 +13,7 @@ env:
     # Test install_ide with no argument (using full version list). This would cause the Travis CI build to take much longer so I have it disabled
     # - INSTALL_IDE_START_VERSION=""
     # Test install_ide using full version list
-    - INSTALL_IDE_START_VERSION="all" SCRIPT_VERBOSITY_LEVEL=0 VERBOSE_COMPILATION="false"
+    - INSTALL_IDE_START_VERSION="all" VERBOSITY_LEVEL=0 VERBOSE_COMPILATION="false"
     # Test install_ide using custom version list. Test the use of the special version names "oldest" and "newest" in a version list. Test use of "hourly" version name.
     - INSTALL_IDE_START_VERSION='("oldest" "1.8.1" "1.8.2" "newest" "hourly")' VERBOSITY_LEVEL=1 VERBOSE_COMPILATION="true"
     # Allowed to fail
@@ -62,6 +62,8 @@ before_install:
   - install_library "https://bitbucket.org/teckel12/arduino-new-ping/downloads/NewPing_v1.8.zip"
   # Test library install from .zip file with rename. If the rename doesn't work then any job verifying with Arduino IDE 1.5.6 or older will hang because GitHub changes the folder name to MPU9250-master, which is not a valid folder name on those IDE versions.
   - install_library "https://github.com/brianc118/MPU9250/archive/master.zip" "MPU9250"
+  # Test library install from .zip file/folder that has a dot in the name
+  - install_library "https://github.com/arduino-libraries/CapacitiveSensor/archive/0.5.1.zip"
   # Test library install from git repo
   - install_library "https://github.com/sfrwmaker/WirelessOregonV2.git"
   # Test library install from git repo with branch
@@ -110,6 +112,8 @@ script:
   # Test library installed from .zip with rename
   - cd "${SKETCHBOOK_FOLDER}/libraries/MPU9250/examples/MPU9250/"
   - build_sketch "MPU9250.ino" "arduino:avr:uno" "false" "newest"
+  # Test library installed from .zip with dot in the folder name
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/CapacitiveSensor-0.5.1/examples/CapacitiveSensorSketch/CapacitiveSensorSketch.pde" "arduino:avr:uno" "false" "newest"
   # Test library installed from .zip
   # Test build_sketch with "all" IDE version name
   - build_sketch "${SKETCHBOOK_FOLDER}/libraries/NewPing/examples/NewPingExample/NewPingExample.pde" "arduino:avr:uno" "false" "all"

--- a/travis-ci/arduino-ci-script/arduino-ci-script.sh
+++ b/travis-ci/arduino-ci-script/arduino-ci-script.sh
@@ -236,6 +236,10 @@ function install_ide()
   eval "$INSTALLED_IDE_VERSION_LIST_ARRAY"
   local IDEversion
   for IDEversion in "${IDEversionListArray[@]}"; do
+    if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -eq 0 ]]; then
+      # If the download/installation process is going slowly when installing a lot of IDE versions this function may cause the build to fail due to exceeding Travis CI's 10 minutes without log output timeout so it's necessary to periodically print something.
+      echo "Installing: $IDEversion"
+    fi
     # Determine download file extension
     local tgzExtensionVersionsRegex="1.5.[0-9]"
     if [[ "$IDEversion" =~ $tgzExtensionVersionsRegex ]]; then
@@ -440,8 +444,8 @@ function install_package()
     else
       cd "$ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER"
 
-      # Clean up the temporary folder
-      rm --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./*.*
+      # Delete everything from the temporary folder
+      find ./ -mindepth 1 -delete
 
       # Download the package
       wget --no-verbose $ARDUINO_CI_SCRIPT_QUIET_OPTION "$packageURL"
@@ -449,8 +453,8 @@ function install_package()
       # Uncompress the package
       extract ./*.*
 
-      # Clean up the temporary folder
-      rm --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./*.*
+      # Delete all files from the temporary folder
+      find ./ -type f -maxdepth 1 -delete
 
       # Install the package
       mv $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/"
@@ -544,13 +548,17 @@ function install_library()
       local -r newFolderName="$2"
       # Download the file to the temporary folder
       cd "$ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER"
-      # Clean up the temporary folder
-      rm --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./*.*
+
+      # Delete everything from the temporary folder
+      find ./ -mindepth 1 -delete
+
       wget --no-verbose $ARDUINO_CI_SCRIPT_QUIET_OPTION "$libraryIdentifier"
 
       extract ./*.*
-      # Clean up the temporary folder
-      rm --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./*.*
+
+      # Delete all files from the temporary folder
+      find ./ -type f -maxdepth 1 -delete
+
       # Install the library
       mv $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/${newFolderName}"
     fi


### PR DESCRIPTION
- Update arduino-ci-script subtree to [1.0.1 tag](https://github.com/per1234/arduino-ci-script/releases/tag/1.0.1)
  - Avoid build timeout during long IDE installations
  - Allow installation of hardware packages or libraries from folders that have a dot in the name
- Fix Travis CI build failure caused by rollout of Trusty Linux distribution

This should fix the build failure noted at https://github.com/MCUdude/MCUdude_corefiles/pull/2#issuecomment-321850558