### PR TITLE
Fix for delay() on 20MHz

### DIFF
--- a/wiring.c
+++ b/wiring.c
@@ -74,7 +74,7 @@ ISR(TIMER0_OVF_vect)
 
 	timer0_fract = f;
 	timer0_millis = m;
-	
+
 	// Since this function was called, timer0 overflowed
 	timer0_overflow_count++;
 }
@@ -99,22 +99,22 @@ unsigned long millis()
 unsigned long micros() {
 	unsigned long m;
 	uint8_t oldSREG = SREG;
-	
+
 	// t will be the number where the timer0 counter stopped
 	uint8_t t;
-	
+
 	// Stop all interrupts
 	cli();
-	
+
 	m = timer0_overflow_count;
-	
+
 	// TCNT0 ist the Timer Counter Register
 #if defined(TCNT0)
 	t = TCNT0;
 #elif defined(TCNT0L)
 	t = TCNT0L;
 #else
-	#error TIMER 0 not defined
+#error TIMER 0 not defined
 #endif
 
 // Timer0 Interrupt Flag Register
@@ -128,20 +128,20 @@ unsigned long micros() {
 
 	// Restore SREG
 	SREG = oldSREG;
-	
+
 #if F_CPU >= 20000000L
 
-// m needs to be multiplied by 819,2 
-// t needs to be multiplied by 3,2
-// then add m and t
-// TODO:
-  return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
+	// m needs to be multiplied by 819,2 
+	// t needs to be multiplied by 3,2
+	// then add m and t
+	// TODO:
+	return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 #else
 
-  // Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 
-  // m is multiplied by 4 (since it was already multiplied by 256)
-  // t is multiplied by 4
-  return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
+	// Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 
+	// m is multiplied by 4 (since it was already multiplied by 256)
+	// t is multiplied by 4
+	return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 #endif
 }
 
@@ -151,7 +151,7 @@ void delay(unsigned long ms)
 
 	while (ms > 0) {
 		yield();
-		while ( ms > 0 && (micros() - start) >= 1000) {
+		while (ms > 0 && (micros() - start) >= 1000) {
 			ms--;
 			start += 1000;
 		}
@@ -187,7 +187,7 @@ void delayMicroseconds(unsigned int us)
 
 	// for a one-microsecond delay, simply return.  the overhead
 	// of the function call takes 18 (20) cycles, which is 1us
-	__asm__ __volatile__ (
+	__asm__ __volatile__(
 		"nop" "\n\t"
 		"nop" "\n\t"
 		"nop" "\n\t"
@@ -268,12 +268,12 @@ void delayMicroseconds(unsigned int us)
 	// per iteration, so execute it us/4 times
 	// us is at least 4, divided by 4 gives us 1 (no zero delay bug)
 	us >>= 2; // us div 4, = 4 cycles
-	
+
 
 #endif
 
 	// busy wait
-	__asm__ __volatile__ (
+	__asm__ __volatile__(
 		"1: sbiw %0,1" "\n\t" // 2 cycles
 		"brne 1b" : "=w" (us) : "0" (us) // 2 cycles
 	);
@@ -285,7 +285,7 @@ void init()
 	// this needs to be called before setup() or some functions won't
 	// work there
 	sei();
-	
+
 	// on the ATmega168, timer 0 is also used for fast hardware pwm
 	// (using phase-correct PWM would mean that timer 0 overflowed half as often
 	// resulting in different millis() behavior on the ATmega8 and ATmega168)
@@ -304,10 +304,10 @@ void init()
 	// this combination is for the ATmega8535, ATmega8, ATmega16, ATmega32, ATmega8515, ATmega162
 	sbi(TCCR0, CS01);
 	sbi(TCCR0, CS00);
-		#if defined(WGM00) && defined(WGM01) // The ATmega8 doesn't have WGM00 and WGM01
-	  sbi(TCCR0, WGM00);
-	  sbi(TCCR0, WGM01);
-	#endif
+#if defined(WGM00) && defined(WGM01) // The ATmega8 doesn't have WGM00 and WGM01
+	sbi(TCCR0, WGM00);
+	sbi(TCCR0, WGM01);
+#endif
 #elif defined(TCCR0B) && defined(CS01) && defined(CS00)
 	// this combination is for the standard 168/328/640/1280/1281/2560/2561
 	sbi(TCCR0B, CS01);
@@ -317,7 +317,7 @@ void init()
 	sbi(TCCR0A, CS01);
 	sbi(TCCR0A, CS00);
 #else
-	#error Timer 0 prescale factor 64 not set correctly
+#error Timer 0 prescale factor 64 not set correctly
 #endif
 
 	// enable timer 0 overflow interrupt
@@ -326,7 +326,7 @@ void init()
 #elif defined(TIMSK0) && defined(TOIE0)
 	sbi(TIMSK0, TOIE0);
 #else
-	#error	Timer 0 overflow interrupt not set correctly
+#error	Timer 0 overflow interrupt not set correctly
 #endif
 
 	// timers 1 and 2 are used for phase-correct hardware pwm
@@ -358,8 +358,8 @@ void init()
 	sbi(TCCR2, CS22);
 #elif defined(TCCR2B) && defined(CS22)
 	sbi(TCCR2B, CS22);
-//#else
-	// Timer 2 not finished (may not be present on this CPU)
+	//#else
+		// Timer 2 not finished (may not be present on this CPU)
 #endif
 
 	// configure timer 2 for phase correct pwm (8-bit)
@@ -367,8 +367,8 @@ void init()
 	sbi(TCCR2, WGM20);
 #elif defined(TCCR2A) && defined(WGM20)
 	sbi(TCCR2A, WGM20);
-//#else
-	// Timer 2 not finished (may not be present on this CPU)
+	//#else
+		// Timer 2 not finished (may not be present on this CPU)
 #endif
 
 #if defined(TCCR3B) && defined(CS31) && defined(WGM30)
@@ -400,31 +400,31 @@ void init()
 
 #if defined(ADCSRA)
 	// set a2d prescaler so we are inside the desired 50-200 KHz range.
-	#if F_CPU >= 16000000 // 16 MHz / 128 = 125 KHz
-		sbi(ADCSRA, ADPS2);
-		sbi(ADCSRA, ADPS1);
-		sbi(ADCSRA, ADPS0);
-	#elif F_CPU >= 8000000 // 8 MHz / 64 = 125 KHz
-		sbi(ADCSRA, ADPS2);
-		sbi(ADCSRA, ADPS1);
-		cbi(ADCSRA, ADPS0);
-	#elif F_CPU >= 4000000 // 4 MHz / 32 = 125 KHz
-		sbi(ADCSRA, ADPS2);
-		cbi(ADCSRA, ADPS1);
-		sbi(ADCSRA, ADPS0);
-	#elif F_CPU >= 2000000 // 2 MHz / 16 = 125 KHz
-		sbi(ADCSRA, ADPS2);
-		cbi(ADCSRA, ADPS1);
-		cbi(ADCSRA, ADPS0);
-	#elif F_CPU >= 1000000 // 1 MHz / 8 = 125 KHz
-		cbi(ADCSRA, ADPS2);
-		sbi(ADCSRA, ADPS1);
-		sbi(ADCSRA, ADPS0);
-	#else // 128 kHz / 2 = 64 KHz -> This is the closest you can get, the prescaler is 2
-		cbi(ADCSRA, ADPS2);
-		cbi(ADCSRA, ADPS1);
-		sbi(ADCSRA, ADPS0);
-	#endif
+#if F_CPU >= 16000000 // 16 MHz / 128 = 125 KHz
+	sbi(ADCSRA, ADPS2);
+	sbi(ADCSRA, ADPS1);
+	sbi(ADCSRA, ADPS0);
+#elif F_CPU >= 8000000 // 8 MHz / 64 = 125 KHz
+	sbi(ADCSRA, ADPS2);
+	sbi(ADCSRA, ADPS1);
+	cbi(ADCSRA, ADPS0);
+#elif F_CPU >= 4000000 // 4 MHz / 32 = 125 KHz
+	sbi(ADCSRA, ADPS2);
+	cbi(ADCSRA, ADPS1);
+	sbi(ADCSRA, ADPS0);
+#elif F_CPU >= 2000000 // 2 MHz / 16 = 125 KHz
+	sbi(ADCSRA, ADPS2);
+	cbi(ADCSRA, ADPS1);
+	cbi(ADCSRA, ADPS0);
+#elif F_CPU >= 1000000 // 1 MHz / 8 = 125 KHz
+	cbi(ADCSRA, ADPS2);
+	sbi(ADCSRA, ADPS1);
+	sbi(ADCSRA, ADPS0);
+#else // 128 kHz / 2 = 64 KHz -> This is the closest you can get, the prescaler is 2
+	cbi(ADCSRA, ADPS2);
+	cbi(ADCSRA, ADPS1);
+	sbi(ADCSRA, ADPS0);
+#endif
 	// enable a2d conversions
 	sbi(ADCSRA, ADEN);
 #endif

--- a/wiring.c
+++ b/wiring.c
@@ -24,20 +24,20 @@
 
 // the prescaler is set so that timer0 ticks every 64 clock cycles, and the
 // the overflow handler is called every 256 ticks.
-// 20MHz: An overflow happens every  819.2  microseconds    --->     0,05 (time of a cycle) * 64 (timer0 tick) * 256 (every 256 ticks timer0 overflows), so this results in 819
+// 20MHz: An overflow happens every 819.2  microseconds ---> 0,05 (time of a cycle) * 64 (timer0 tick) * 256 (every 256 ticks timer0 overflows), so this results in 819
 // 16MHz: An overflow happens every 1024 microseconds
 #define MICROSECONDS_PER_TIMER0_OVERFLOW (clockCyclesToMicroseconds(64 * 256))
 
 // the whole number of milliseconds per timer0 overflow
-// For 20MHz this would be 0 (because 819)
-// For 16MHz this would be 1 (because 1024)
+// For 20MHz this would be 0 (because of 819)
+// For 16MHz this would be 1 (because of 1024)
 #define MILLIS_INC (MICROSECONDS_PER_TIMER0_OVERFLOW / 1000)
 
 // the fractional number of milliseconds per timer0 overflow. we shift right
 // by three to fit these numbers into a byte. (for the clock speeds we care
 // about - 8 and 16 MHz - this doesn't lose precision.)
 // For 16 MHz: 24 (1024 % 1000) gets shiftet right by 3 which results in 3
-// For 20MHz 819 (819 % 1000) gets shiftet right by 3 which results in 102 (precision was lost)
+// For 20 MHz: 819 (819 % 1000) gets shiftet right by 3 which results in 102 (precision was lost)
 #define FRACT_INC ((MICROSECONDS_PER_TIMER0_OVERFLOW % 1000) >> 3)
 
 // 1000 shift by 3 (to fit it in a byte) to the right is 125 (no precision lost) 
@@ -46,12 +46,9 @@
 // 1000 shift by 2 (to fit in a byte) to the right is 250 (no precision lost)
 #define FRACT_MAX2 (1000 >> 2)
 
-
 volatile unsigned long timer0_overflow_count = 0;
-
 volatile unsigned long timer0_millis = 0;
 static unsigned char timer0_fract = 0;
-
 
 // timer0 interrupt routine ,- is called every time timer0 overflows
 #if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
@@ -71,7 +68,6 @@ ISR(TIMER0_OVF_vect)
         f -= FRACT_MAX;
         m += 1;
     }
-
     timer0_fract = f;
     timer0_millis = m;
 
@@ -79,9 +75,6 @@ ISR(TIMER0_OVF_vect)
     timer0_overflow_count++;
 }
 
-
-
-// 
 unsigned long millis()
 {
     unsigned long m;
@@ -108,7 +101,7 @@ unsigned long micros() {
 
     m = timer0_overflow_count;
 
-    // TCNT0 ist the Timer Counter Register
+    // TCNT0 : The Timer Counter Register
 #if defined(TCNT0)
     t = TCNT0;
 #elif defined(TCNT0L)
@@ -117,7 +110,7 @@ unsigned long micros() {
 #error TIMER 0 not defined
 #endif
 
-// Timer0 Interrupt Flag Register
+    // Timer0 Interrupt Flag Register
 #ifdef TIFR0
     if ((TIFR0 & _BV(TOV0)) && (t < 255))
         m++;

--- a/wiring.c
+++ b/wiring.c
@@ -99,8 +99,11 @@ unsigned long micros() {
 #endif
 
   SREG = oldSREG;
+#if F_CPU == 20000000L
   
+#else
   return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
+#endif
 }
 
 void delay(unsigned long ms)

--- a/wiring.c
+++ b/wiring.c
@@ -44,7 +44,7 @@
 #define FRACT_MAX (1000 >> 3)
 
 // 1000 shift by 2 (to fit in a byte) to the right is 250 (no precision lost)
-#define FRACT_MAX (1000 >> 2)
+#define FRACT_MAX2 (1000 >> 2)
 
 
 volatile unsigned long timer0_overflow_count = 0;
@@ -130,12 +130,14 @@ unsigned long micros() {
 	SREG = oldSREG;
 
 #if F_CPU >= 20000000L
+	//Technically  m needs to be multiplied by 819,2 
+	// and t needs to be multiplied by 3,2
+	// then we add m and t
 
-	// m needs to be multiplied by 819,2 
-	// t needs to be multiplied by 3,2
-	// then add m and t
-	// TODO:
-	return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
+	// Multiply m by 256 (to fit t) and add t
+	m = (m << 8) + t;
+
+	return m + (m << 1) + (m >> 2) - (m >> 4);
 #else
 
 	// Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 

--- a/wiring.c
+++ b/wiring.c
@@ -60,23 +60,23 @@ ISR(TIM0_OVF_vect)
 ISR(TIMER0_OVF_vect)
 #endif
 {
-	// copy these to local variables so they can be stored in registers
-	// (volatile variables must be read from memory on every access, so this saves time)
-	unsigned long m = timer0_millis;
-	unsigned char f = timer0_fract;
+    // copy these to local variables so they can be stored in registers
+    // (volatile variables must be read from memory on every access, so this saves time)
+    unsigned long m = timer0_millis;
+    unsigned char f = timer0_fract;
 
-	m += MILLIS_INC;
-	f += FRACT_INC;
-	if (f >= FRACT_MAX) {
-		f -= FRACT_MAX;
-		m += 1;
-	}
+    m += MILLIS_INC;
+    f += FRACT_INC;
+    if (f >= FRACT_MAX) {
+        f -= FRACT_MAX;
+        m += 1;
+    }
 
-	timer0_fract = f;
-	timer0_millis = m;
+    timer0_fract = f;
+    timer0_millis = m;
 
-	// Since this function was called, timer0 overflowed
-	timer0_overflow_count++;
+    // Since this function was called, timer0 overflowed
+    timer0_overflow_count++;
 }
 
 
@@ -84,359 +84,359 @@ ISR(TIMER0_OVF_vect)
 // 
 unsigned long millis()
 {
-	unsigned long m;
-	uint8_t oldSREG = SREG;
+    unsigned long m;
+    uint8_t oldSREG = SREG;
 
-	// disable interrupts while we read timer0_millis or we might get an
-	// inconsistent value (e.g. in the middle of a write to timer0_millis)
-	cli();
-	m = timer0_millis;
-	SREG = oldSREG;
+    // disable interrupts while we read timer0_millis or we might get an
+    // inconsistent value (e.g. in the middle of a write to timer0_millis)
+    cli();
+    m = timer0_millis;
+    SREG = oldSREG;
 
-	return m;
+    return m;
 }
 
 unsigned long micros() {
-	unsigned long m;
-	uint8_t oldSREG = SREG;
+    unsigned long m;
+    uint8_t oldSREG = SREG;
 
-	// t will be the number where the timer0 counter stopped
-	uint8_t t;
+    // t will be the number where the timer0 counter stopped
+    uint8_t t;
 
-	// Stop all interrupts
-	cli();
+    // Stop all interrupts
+    cli();
 
-	m = timer0_overflow_count;
+    m = timer0_overflow_count;
 
-	// TCNT0 ist the Timer Counter Register
+    // TCNT0 ist the Timer Counter Register
 #if defined(TCNT0)
-	t = TCNT0;
+    t = TCNT0;
 #elif defined(TCNT0L)
-	t = TCNT0L;
+    t = TCNT0L;
 #else
 #error TIMER 0 not defined
 #endif
 
 // Timer0 Interrupt Flag Register
 #ifdef TIFR0
-	if ((TIFR0 & _BV(TOV0)) && (t < 255))
-		m++;
+    if ((TIFR0 & _BV(TOV0)) && (t < 255))
+        m++;
 #else
-	if ((TIFR & _BV(TOV0)) && (t < 255))
-		m++;
+    if ((TIFR & _BV(TOV0)) && (t < 255))
+        m++;
 #endif
 
-	// Restore SREG
-	SREG = oldSREG;
+    // Restore SREG
+    SREG = oldSREG;
 
 #if F_CPU >= 20000000L
-	//Technically  m needs to be multiplied by 819,2 
-	// and t needs to be multiplied by 3,2
-	// then we add m and t
+    //Technically  m needs to be multiplied by 819,2 
+    // and t needs to be multiplied by 3,2
+    // then we add m and t
 
-	// Multiply m by 256 (to fit t) and add t
-	m = (m << 8) + t;
+    // Multiply m by 256 (to fit t) and add t
+    m = (m << 8) + t;
 
-	return m + (m << 1) + (m >> 2) - (m >> 4);
+    return m + (m << 1) + (m >> 2) - (m >> 4);
 #else
 
-	// Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 
-	// m is multiplied by 4 (since it was already multiplied by 256)
-	// t is multiplied by 4
-	return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
+    // Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 
+    // m is multiplied by 4 (since it was already multiplied by 256)
+    // t is multiplied by 4
+    return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 #endif
 }
 
 void delay(unsigned long ms)
 {
-	uint32_t start = micros();
+    uint32_t start = micros();
 
-	while (ms > 0) {
-		yield();
-		while (ms > 0 && (micros() - start) >= 1000) {
-			ms--;
-			start += 1000;
-		}
-	}
+    while (ms > 0) {
+        yield();
+        while (ms > 0 && (micros() - start) >= 1000) {
+            ms--;
+            start += 1000;
+        }
+    }
 }
 
 /* Delay for the given number of microseconds.  Assumes a 1, 8, 12, 16, 20 or 24 MHz clock. */
 void delayMicroseconds(unsigned int us)
 {
-	// call = 4 cycles + 2 to 4 cycles to init us(2 for constant delay, 4 for variable)
+    // call = 4 cycles + 2 to 4 cycles to init us(2 for constant delay, 4 for variable)
 
-	// calling avrlib's delay_us() function with low values (e.g. 1 or
-	// 2 microseconds) gives delays longer than desired.
-	//delay_us(us);
+    // calling avrlib's delay_us() function with low values (e.g. 1 or
+    // 2 microseconds) gives delays longer than desired.
+    //delay_us(us);
 #if F_CPU >= 24000000L
-	// for the 24 MHz clock for the aventurous ones, trying to overclock
+    // for the 24 MHz clock for the aventurous ones, trying to overclock
 
-	// zero delay fix
-	if (!us) return; //  = 3 cycles, (4 when true)
+    // zero delay fix
+    if (!us) return; //  = 3 cycles, (4 when true)
 
-	// the following loop takes a 1/6 of a microsecond (4 cycles)
-	// per iteration, so execute it six times for each microsecond of
-	// delay requested.
-	us *= 6; // x6 us, = 7 cycles
+    // the following loop takes a 1/6 of a microsecond (4 cycles)
+    // per iteration, so execute it six times for each microsecond of
+    // delay requested.
+    us *= 6; // x6 us, = 7 cycles
 
-	// account for the time taken in the preceeding commands.
-	// we just burned 22 (24) cycles above, remove 5, (5*4=20)
-	// us is at least 6 so we can substract 5
-	us -= 5; //=2 cycles
+    // account for the time taken in the preceeding commands.
+    // we just burned 22 (24) cycles above, remove 5, (5*4=20)
+    // us is at least 6 so we can substract 5
+    us -= 5; //=2 cycles
 
 #elif F_CPU >= 20000000L
-	// for the 20 MHz clock on rare Arduino boards
+    // for the 20 MHz clock on rare Arduino boards
 
-	// for a one-microsecond delay, simply return.  the overhead
-	// of the function call takes 18 (20) cycles, which is 1us
-	__asm__ __volatile__(
-		"nop" "\n\t"
-		"nop" "\n\t"
-		"nop" "\n\t"
-		"nop"); //just waiting 4 cycles
-	if (us <= 1) return; //  = 3 cycles, (4 when true)
+    // for a one-microsecond delay, simply return.  the overhead
+    // of the function call takes 18 (20) cycles, which is 1us
+    __asm__ __volatile__(
+        "nop" "\n\t"
+        "nop" "\n\t"
+        "nop" "\n\t"
+        "nop"); //just waiting 4 cycles
+    if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-	// the following loop takes a 1/5 of a microsecond (4 cycles)
-	// per iteration, so execute it five times for each microsecond of
-	// delay requested.
-	us = (us << 2) + us; // x5 us, = 7 cycles
+    // the following loop takes a 1/5 of a microsecond (4 cycles)
+    // per iteration, so execute it five times for each microsecond of
+    // delay requested.
+    us = (us << 2) + us; // x5 us, = 7 cycles
 
-	// account for the time taken in the preceeding commands.
-	// we just burned 26 (28) cycles above, remove 7, (7*4=28)
-	// us is at least 10 so we can substract 7
-	us -= 7; // 2 cycles
+    // account for the time taken in the preceeding commands.
+    // we just burned 26 (28) cycles above, remove 7, (7*4=28)
+    // us is at least 10 so we can substract 7
+    us -= 7; // 2 cycles
 
 #elif F_CPU >= 16000000L
-	// for the 16 MHz clock on most Arduino boards
+    // for the 16 MHz clock on most Arduino boards
 
-	// for a one-microsecond delay, simply return.  the overhead
-	// of the function call takes 14 (16) cycles, which is 1us
-	if (us <= 1) return; //  = 3 cycles, (4 when true)
+    // for a one-microsecond delay, simply return.  the overhead
+    // of the function call takes 14 (16) cycles, which is 1us
+    if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-	// the following loop takes 1/4 of a microsecond (4 cycles)
-	// per iteration, so execute it four times for each microsecond of
-	// delay requested.
-	us <<= 2; // x4 us, = 4 cycles
+    // the following loop takes 1/4 of a microsecond (4 cycles)
+    // per iteration, so execute it four times for each microsecond of
+    // delay requested.
+    us <<= 2; // x4 us, = 4 cycles
 
-	// account for the time taken in the preceeding commands.
-	// we just burned 19 (21) cycles above, remove 5, (5*4=20)
-	// us is at least 8 so we can substract 5
-	us -= 5; // = 2 cycles,
+    // account for the time taken in the preceeding commands.
+    // we just burned 19 (21) cycles above, remove 5, (5*4=20)
+    // us is at least 8 so we can substract 5
+    us -= 5; // = 2 cycles,
 
 #elif F_CPU >= 12000000L
-	// for the 12 MHz clock if somebody is working with USB
+    // for the 12 MHz clock if somebody is working with USB
 
-	// for a 1 microsecond delay, simply return.  the overhead
-	// of the function call takes 14 (16) cycles, which is 1.5us
-	if (us <= 1) return; //  = 3 cycles, (4 when true)
+    // for a 1 microsecond delay, simply return.  the overhead
+    // of the function call takes 14 (16) cycles, which is 1.5us
+    if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-	// the following loop takes 1/3 of a microsecond (4 cycles)
-	// per iteration, so execute it three times for each microsecond of
-	// delay requested.
-	us = (us << 1) + us; // x3 us, = 5 cycles
+    // the following loop takes 1/3 of a microsecond (4 cycles)
+    // per iteration, so execute it three times for each microsecond of
+    // delay requested.
+    us = (us << 1) + us; // x3 us, = 5 cycles
 
-	// account for the time taken in the preceeding commands.
-	// we just burned 20 (22) cycles above, remove 5, (5*4=20)
-	// us is at least 6 so we can substract 5
-	us -= 5; //2 cycles
+    // account for the time taken in the preceeding commands.
+    // we just burned 20 (22) cycles above, remove 5, (5*4=20)
+    // us is at least 6 so we can substract 5
+    us -= 5; //2 cycles
 
 #elif F_CPU >= 8000000L
-	// for the 8 MHz internal clock
+    // for the 8 MHz internal clock
 
-	// for a 1 and 2 microsecond delay, simply return.  the overhead
-	// of the function call takes 14 (16) cycles, which is 2us
-	if (us <= 2) return; //  = 3 cycles, (4 when true)
+    // for a 1 and 2 microsecond delay, simply return.  the overhead
+    // of the function call takes 14 (16) cycles, which is 2us
+    if (us <= 2) return; //  = 3 cycles, (4 when true)
 
-	// the following loop takes 1/2 of a microsecond (4 cycles)
-	// per iteration, so execute it twice for each microsecond of
-	// delay requested.
-	us <<= 1; //x2 us, = 2 cycles
+    // the following loop takes 1/2 of a microsecond (4 cycles)
+    // per iteration, so execute it twice for each microsecond of
+    // delay requested.
+    us <<= 1; //x2 us, = 2 cycles
 
-	// account for the time taken in the preceeding commands.
-	// we just burned 17 (19) cycles above, remove 4, (4*4=16)
-	// us is at least 6 so we can substract 4
-	us -= 4; // = 2 cycles
+    // account for the time taken in the preceeding commands.
+    // we just burned 17 (19) cycles above, remove 4, (4*4=16)
+    // us is at least 6 so we can substract 4
+    us -= 4; // = 2 cycles
 
 #else
-	// for the 1 MHz internal clock (default settings for common Atmega microcontrollers)
+    // for the 1 MHz internal clock (default settings for common Atmega microcontrollers)
 
-	// the overhead of the function calls is 14 (16) cycles
-	if (us <= 16) return; //= 3 cycles, (4 when true)
-	if (us <= 25) return; //= 3 cycles, (4 when true), (must be at least 25 if we want to substract 22)
+    // the overhead of the function calls is 14 (16) cycles
+    if (us <= 16) return; //= 3 cycles, (4 when true)
+    if (us <= 25) return; //= 3 cycles, (4 when true), (must be at least 25 if we want to substract 22)
 
-	// compensate for the time taken by the preceeding and next commands (about 22 cycles)
-	us -= 22; // = 2 cycles
-	// the following loop takes 4 microseconds (4 cycles)
-	// per iteration, so execute it us/4 times
-	// us is at least 4, divided by 4 gives us 1 (no zero delay bug)
-	us >>= 2; // us div 4, = 4 cycles
+    // compensate for the time taken by the preceeding and next commands (about 22 cycles)
+    us -= 22; // = 2 cycles
+    // the following loop takes 4 microseconds (4 cycles)
+    // per iteration, so execute it us/4 times
+    // us is at least 4, divided by 4 gives us 1 (no zero delay bug)
+    us >>= 2; // us div 4, = 4 cycles
 
 
 #endif
 
-	// busy wait
-	__asm__ __volatile__(
-		"1: sbiw %0,1" "\n\t" // 2 cycles
-		"brne 1b" : "=w" (us) : "0" (us) // 2 cycles
-	);
-	// return = 4 cycles
+    // busy wait
+    __asm__ __volatile__(
+        "1: sbiw %0,1" "\n\t" // 2 cycles
+        "brne 1b" : "=w" (us) : "0" (us) // 2 cycles
+    );
+    // return = 4 cycles
 }
 
 void init()
 {
-	// this needs to be called before setup() or some functions won't
-	// work there
-	sei();
+    // this needs to be called before setup() or some functions won't
+    // work there
+    sei();
 
-	// on the ATmega168, timer 0 is also used for fast hardware pwm
-	// (using phase-correct PWM would mean that timer 0 overflowed half as often
-	// resulting in different millis() behavior on the ATmega8 and ATmega168)
+    // on the ATmega168, timer 0 is also used for fast hardware pwm
+    // (using phase-correct PWM would mean that timer 0 overflowed half as often
+    // resulting in different millis() behavior on the ATmega8 and ATmega168)
 #if defined(TCCR0A) && defined(WGM01)
-	sbi(TCCR0A, WGM01);
-	sbi(TCCR0A, WGM00);
+    sbi(TCCR0A, WGM01);
+    sbi(TCCR0A, WGM00);
 #endif
 
-	// set timer 0 prescale factor to 64
+    // set timer 0 prescale factor to 64
 #if defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
-	// CPU specific: different values for the ATmega64/128
-	sbi(TCCR0, WGM00);
-	sbi(TCCR0, WGM01);
-	sbi(TCCR0, CS02);
+    // CPU specific: different values for the ATmega64/128
+    sbi(TCCR0, WGM00);
+    sbi(TCCR0, WGM01);
+    sbi(TCCR0, CS02);
 #elif defined(TCCR0) && defined(CS01) && defined(CS00)
-	// this combination is for the ATmega8535, ATmega8, ATmega16, ATmega32, ATmega8515, ATmega162
-	sbi(TCCR0, CS01);
-	sbi(TCCR0, CS00);
+    // this combination is for the ATmega8535, ATmega8, ATmega16, ATmega32, ATmega8515, ATmega162
+    sbi(TCCR0, CS01);
+    sbi(TCCR0, CS00);
 #if defined(WGM00) && defined(WGM01) // The ATmega8 doesn't have WGM00 and WGM01
-	sbi(TCCR0, WGM00);
-	sbi(TCCR0, WGM01);
+    sbi(TCCR0, WGM00);
+    sbi(TCCR0, WGM01);
 #endif
 #elif defined(TCCR0B) && defined(CS01) && defined(CS00)
-	// this combination is for the standard 168/328/640/1280/1281/2560/2561
-	sbi(TCCR0B, CS01);
-	sbi(TCCR0B, CS00);
+    // this combination is for the standard 168/328/640/1280/1281/2560/2561
+    sbi(TCCR0B, CS01);
+    sbi(TCCR0B, CS00);
 #elif defined(TCCR0A) && defined(CS01) && defined(CS00)
-	// this combination is for the __AVR_ATmega645__ series
-	sbi(TCCR0A, CS01);
-	sbi(TCCR0A, CS00);
+    // this combination is for the __AVR_ATmega645__ series
+    sbi(TCCR0A, CS01);
+    sbi(TCCR0A, CS00);
 #else
 #error Timer 0 prescale factor 64 not set correctly
 #endif
 
-	// enable timer 0 overflow interrupt
+    // enable timer 0 overflow interrupt
 #if defined(TIMSK) && defined(TOIE0)
-	sbi(TIMSK, TOIE0);
+    sbi(TIMSK, TOIE0);
 #elif defined(TIMSK0) && defined(TOIE0)
-	sbi(TIMSK0, TOIE0);
+    sbi(TIMSK0, TOIE0);
 #else
-#error	Timer 0 overflow interrupt not set correctly
+#error  Timer 0 overflow interrupt not set correctly
 #endif
 
-	// timers 1 and 2 are used for phase-correct hardware pwm
-	// this is better for motors as it ensures an even waveform
-	// note, however, that fast pwm mode can achieve a frequency of up
-	// 8 MHz (with a 16 MHz clock) at 50% duty cycle
+    // timers 1 and 2 are used for phase-correct hardware pwm
+    // this is better for motors as it ensures an even waveform
+    // note, however, that fast pwm mode can achieve a frequency of up
+    // 8 MHz (with a 16 MHz clock) at 50% duty cycle
 
 #if defined(TCCR1B) && defined(CS11) && defined(CS10)
-	TCCR1B = 0;
+    TCCR1B = 0;
 
-	// set timer 1 prescale factor to 64
-	sbi(TCCR1B, CS11);
+    // set timer 1 prescale factor to 64
+    sbi(TCCR1B, CS11);
 #if F_CPU >= 8000000L
-	sbi(TCCR1B, CS10);
+    sbi(TCCR1B, CS10);
 #endif
 #elif defined(TCCR1) && defined(CS11) && defined(CS10)
-	sbi(TCCR1, CS11);
+    sbi(TCCR1, CS11);
 #if F_CPU >= 8000000L
-	sbi(TCCR1, CS10);
+    sbi(TCCR1, CS10);
 #endif
 #endif
-	// put timer 1 in 8-bit phase correct pwm mode
+    // put timer 1 in 8-bit phase correct pwm mode
 #if defined(TCCR1A) && defined(WGM10)
-	sbi(TCCR1A, WGM10);
+    sbi(TCCR1A, WGM10);
 #endif
 
-	// set timer 2 prescale factor to 64
+    // set timer 2 prescale factor to 64
 #if defined(TCCR2) && defined(CS22)
-	sbi(TCCR2, CS22);
+    sbi(TCCR2, CS22);
 #elif defined(TCCR2B) && defined(CS22)
-	sbi(TCCR2B, CS22);
-	//#else
-		// Timer 2 not finished (may not be present on this CPU)
+    sbi(TCCR2B, CS22);
+    //#else
+        // Timer 2 not finished (may not be present on this CPU)
 #endif
 
-	// configure timer 2 for phase correct pwm (8-bit)
+    // configure timer 2 for phase correct pwm (8-bit)
 #if defined(TCCR2) && defined(WGM20)
-	sbi(TCCR2, WGM20);
+    sbi(TCCR2, WGM20);
 #elif defined(TCCR2A) && defined(WGM20)
-	sbi(TCCR2A, WGM20);
-	//#else
-		// Timer 2 not finished (may not be present on this CPU)
+    sbi(TCCR2A, WGM20);
+    //#else
+        // Timer 2 not finished (may not be present on this CPU)
 #endif
 
 #if defined(TCCR3B) && defined(CS31) && defined(WGM30)
-	sbi(TCCR3B, CS31);		// set timer 3 prescale factor to 64
-	sbi(TCCR3B, CS30);
-	sbi(TCCR3A, WGM30);		// put timer 3 in 8-bit phase correct pwm mode
+    sbi(TCCR3B, CS31);      // set timer 3 prescale factor to 64
+    sbi(TCCR3B, CS30);
+    sbi(TCCR3A, WGM30);     // put timer 3 in 8-bit phase correct pwm mode
 #endif
 
 #if defined(TCCR4A) && defined(TCCR4B) && defined(TCCR4D) /* beginning of timer4 block for 32U4 and similar */
-	sbi(TCCR4B, CS42);		// set timer4 prescale factor to 64
-	sbi(TCCR4B, CS41);
-	sbi(TCCR4B, CS40);
-	sbi(TCCR4D, WGM40);		// put timer 4 in phase- and frequency-correct PWM mode	
-	sbi(TCCR4A, PWM4A);		// enable PWM mode for comparator OCR4A
-	sbi(TCCR4C, PWM4D);		// enable PWM mode for comparator OCR4D
+    sbi(TCCR4B, CS42);      // set timer4 prescale factor to 64
+    sbi(TCCR4B, CS41);
+    sbi(TCCR4B, CS40);
+    sbi(TCCR4D, WGM40);     // put timer 4 in phase- and frequency-correct PWM mode 
+    sbi(TCCR4A, PWM4A);     // enable PWM mode for comparator OCR4A
+    sbi(TCCR4C, PWM4D);     // enable PWM mode for comparator OCR4D
 #else /* beginning of timer4 block for ATMEGA640, ATMEGA1280 and ATMEGA2560 */
 #if defined(TCCR4B) && defined(CS41) && defined(WGM40)
-	sbi(TCCR4B, CS41);		// set timer 4 prescale factor to 64
-	sbi(TCCR4B, CS40);
-	sbi(TCCR4A, WGM40);		// put timer 4 in 8-bit phase correct pwm mode
+    sbi(TCCR4B, CS41);      // set timer 4 prescale factor to 64
+    sbi(TCCR4B, CS40);
+    sbi(TCCR4A, WGM40);     // put timer 4 in 8-bit phase correct pwm mode
 #endif
-#endif /* end timer4 block for ATMEGA640/1280/2560 and similar */	
+#endif /* end timer4 block for ATMEGA640/1280/2560 and similar */   
 
 #if defined(TCCR5B) && defined(CS51) && defined(WGM50)
-	sbi(TCCR5B, CS51);		// set timer 5 prescale factor to 64
-	sbi(TCCR5B, CS50);
-	sbi(TCCR5A, WGM50);		// put timer 5 in 8-bit phase correct pwm mode
+    sbi(TCCR5B, CS51);      // set timer 5 prescale factor to 64
+    sbi(TCCR5B, CS50);
+    sbi(TCCR5A, WGM50);     // put timer 5 in 8-bit phase correct pwm mode
 #endif
 
 #if defined(ADCSRA)
-	// set a2d prescaler so we are inside the desired 50-200 KHz range.
+    // set a2d prescaler so we are inside the desired 50-200 KHz range.
 #if F_CPU >= 16000000 // 16 MHz / 128 = 125 KHz
-	sbi(ADCSRA, ADPS2);
-	sbi(ADCSRA, ADPS1);
-	sbi(ADCSRA, ADPS0);
+    sbi(ADCSRA, ADPS2);
+    sbi(ADCSRA, ADPS1);
+    sbi(ADCSRA, ADPS0);
 #elif F_CPU >= 8000000 // 8 MHz / 64 = 125 KHz
-	sbi(ADCSRA, ADPS2);
-	sbi(ADCSRA, ADPS1);
-	cbi(ADCSRA, ADPS0);
+    sbi(ADCSRA, ADPS2);
+    sbi(ADCSRA, ADPS1);
+    cbi(ADCSRA, ADPS0);
 #elif F_CPU >= 4000000 // 4 MHz / 32 = 125 KHz
-	sbi(ADCSRA, ADPS2);
-	cbi(ADCSRA, ADPS1);
-	sbi(ADCSRA, ADPS0);
+    sbi(ADCSRA, ADPS2);
+    cbi(ADCSRA, ADPS1);
+    sbi(ADCSRA, ADPS0);
 #elif F_CPU >= 2000000 // 2 MHz / 16 = 125 KHz
-	sbi(ADCSRA, ADPS2);
-	cbi(ADCSRA, ADPS1);
-	cbi(ADCSRA, ADPS0);
+    sbi(ADCSRA, ADPS2);
+    cbi(ADCSRA, ADPS1);
+    cbi(ADCSRA, ADPS0);
 #elif F_CPU >= 1000000 // 1 MHz / 8 = 125 KHz
-	cbi(ADCSRA, ADPS2);
-	sbi(ADCSRA, ADPS1);
-	sbi(ADCSRA, ADPS0);
+    cbi(ADCSRA, ADPS2);
+    sbi(ADCSRA, ADPS1);
+    sbi(ADCSRA, ADPS0);
 #else // 128 kHz / 2 = 64 KHz -> This is the closest you can get, the prescaler is 2
-	cbi(ADCSRA, ADPS2);
-	cbi(ADCSRA, ADPS1);
-	sbi(ADCSRA, ADPS0);
+    cbi(ADCSRA, ADPS2);
+    cbi(ADCSRA, ADPS1);
+    sbi(ADCSRA, ADPS0);
 #endif
-	// enable a2d conversions
-	sbi(ADCSRA, ADEN);
+    // enable a2d conversions
+    sbi(ADCSRA, ADEN);
 #endif
 
-	// the bootloader connects pins 0 and 1 to the USART; disconnect them
-	// here so they can be used as normal digital i/o; they will be
-	// reconnected in Serial.begin()
+    // the bootloader connects pins 0 and 1 to the USART; disconnect them
+    // here so they can be used as normal digital i/o; they will be
+    // reconnected in Serial.begin()
 #if defined(UCSRB)
-	UCSRB = 0;
+    UCSRB = 0;
 #elif defined(UCSR0B)
-	UCSR0B = 0;
+    UCSR0B = 0;
 #endif
 }

--- a/wiring.c
+++ b/wiring.c
@@ -86,48 +86,48 @@ unsigned long millis()
 }
 
 unsigned long micros() {
-    unsigned long m;
-    uint8_t oldSREG = SREG;
-    // t will be the number where the timer0 counter stopped
-    uint8_t t;
+  unsigned long m;
+  uint8_t oldSREG = SREG;
+  // t will be the number where the timer0 counter stopped
+  uint8_t t;
 
-    // Stop all interrupts
-    cli();
-    m = timer0_overflow_count;
+  // Stop all interrupts
+  cli();
+  m = timer0_overflow_count;
 
-    // TCNT0 : The Timer Counter Register
+  // TCNT0 : The Timer Counter Register
 #if defined(TCNT0)
-    t = TCNT0;
+  t = TCNT0;
 #elif defined(TCNT0L)
-    t = TCNT0L;
+  t = TCNT0L;
 #else
 #error TIMER 0 not defined
 #endif
 
-    // Timer0 Interrupt Flag Register
+  // Timer0 Interrupt Flag Register
 #ifdef TIFR0
-    if ((TIFR0 & _BV(TOV0)) && (t < 255))
-        m++;
+  if ((TIFR0 & _BV(TOV0)) && (t < 255))
+    m++;
 #else
-    if ((TIFR & _BV(TOV0)) && (t < 255))
-        m++;
+  if ((TIFR & _BV(TOV0)) && (t < 255))
+    m++;
 #endif
-    // Restore SREG
-    SREG = oldSREG;
+  // Restore SREG
+  SREG = oldSREG;
 
 #if F_CPU >= 20000000L
-    //Technically  m needs to be multiplied by 819,2 
-    // and t needs to be multiplied by 3,2
-    // then we add m and t
+  //Technically  m needs to be multiplied by 819,2 
+  // and t needs to be multiplied by 3,2
+  // then we add m and t
 
-    // Multiply m by 256 (to fit t) and add t
-    m = (m << 8) + t;
-    return m + (m << 1) + (m >> 2) - (m >> 4);
+  // Multiply m by 256 (to fit t) and add t
+  m = (m << 8) + t;
+  return m + (m << 1) + (m >> 2) - (m >> 4);
 #else
-    // Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 
-    // m is multiplied by 4 (since it was already multiplied by 256)
-    // t is multiplied by 4
-    return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
+  // Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 
+  // m is multiplied by 4 (since it was already multiplied by 256)
+  // t is multiplied by 4
+  return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 #endif
 }
 

--- a/wiring.c
+++ b/wiring.c
@@ -88,13 +88,11 @@ unsigned long millis()
 unsigned long micros() {
     unsigned long m;
     uint8_t oldSREG = SREG;
-
     // t will be the number where the timer0 counter stopped
     uint8_t t;
 
     // Stop all interrupts
     cli();
-
     m = timer0_overflow_count;
 
     // TCNT0 : The Timer Counter Register

--- a/wiring.c
+++ b/wiring.c
@@ -39,10 +39,7 @@
 // For 16 MHz: 24 (1024 % 1000) gets shiftet right by 3 which results in 3
 // For 20 MHz: 819 (819 % 1000) gets shiftet right by 3 which results in 102 (precision was lost)
 #define FRACT_INC ((MICROSECONDS_PER_TIMER0_OVERFLOW % 1000) >> 3)
-
-// 1000 shift by 3 (to fit it in a byte) to the right is 125 (no precision lost) 
 #define FRACT_MAX (1000 >> 3)
-
 // 1000 shift by 2 (to fit in a byte) to the right is 250 (no precision lost)
 #define FRACT_MAX2 (1000 >> 2)
 
@@ -57,36 +54,35 @@ ISR(TIM0_OVF_vect)
 ISR(TIMER0_OVF_vect)
 #endif
 {
-    // copy these to local variables so they can be stored in registers
-    // (volatile variables must be read from memory on every access, so this saves time)
-    unsigned long m = timer0_millis;
-    unsigned char f = timer0_fract;
+  // copy these to local variables so they can be stored in registers
+  // (volatile variables must be read from memory on every access)
+  unsigned long m = timer0_millis;
+  unsigned char f = timer0_fract;
 
-    m += MILLIS_INC;
-    f += FRACT_INC;
-    if (f >= FRACT_MAX) {
-        f -= FRACT_MAX;
-        m += 1;
-    }
-    timer0_fract = f;
-    timer0_millis = m;
+  m += MILLIS_INC;
+  f += FRACT_INC;
+  if (f >= FRACT_MAX) {
+    f -= FRACT_MAX;
+    m += 1;
+  }
 
-    // Since this function was called, timer0 overflowed
-    timer0_overflow_count++;
+  timer0_fract = f;
+  timer0_millis = m;
+  timer0_overflow_count++;
 }
 
 unsigned long millis()
 {
-    unsigned long m;
-    uint8_t oldSREG = SREG;
+  unsigned long m;
+  uint8_t oldSREG = SREG;
 
-    // disable interrupts while we read timer0_millis or we might get an
-    // inconsistent value (e.g. in the middle of a write to timer0_millis)
-    cli();
-    m = timer0_millis;
-    SREG = oldSREG;
+  // disable interrupts while we read timer0_millis or we might get an
+  // inconsistent value (e.g. in the middle of a write to timer0_millis)
+  cli();
+  m = timer0_millis;
+  SREG = oldSREG;
 
-    return m;
+  return m;
 }
 
 unsigned long micros() {
@@ -142,294 +138,294 @@ unsigned long micros() {
 
 void delay(unsigned long ms)
 {
-    uint32_t start = micros();
+  uint32_t start = micros();
 
-    while (ms > 0) {
-        yield();
-        while (ms > 0 && (micros() - start) >= 1000) {
-            ms--;
-            start += 1000;
-        }
+  while (ms > 0) {
+    yield();
+    while ( ms > 0 && (micros() - start) >= 1000) {
+      ms--;
+      start += 1000;
     }
+  }
 }
 
 /* Delay for the given number of microseconds.  Assumes a 1, 8, 12, 16, 20 or 24 MHz clock. */
 void delayMicroseconds(unsigned int us)
 {
-    // call = 4 cycles + 2 to 4 cycles to init us(2 for constant delay, 4 for variable)
+  // call = 4 cycles + 2 to 4 cycles to init us(2 for constant delay, 4 for variable)
 
-    // calling avrlib's delay_us() function with low values (e.g. 1 or
-    // 2 microseconds) gives delays longer than desired.
-    //delay_us(us);
+  // calling avrlib's delay_us() function with low values (e.g. 1 or
+  // 2 microseconds) gives delays longer than desired.
+  //delay_us(us);
 #if F_CPU >= 24000000L
-    // for the 24 MHz clock for the aventurous ones, trying to overclock
+  // for the 24 MHz clock for the aventurous ones, trying to overclock
 
-    // zero delay fix
-    if (!us) return; //  = 3 cycles, (4 when true)
+  // zero delay fix
+  if (!us) return; //  = 3 cycles, (4 when true)
 
-    // the following loop takes a 1/6 of a microsecond (4 cycles)
-    // per iteration, so execute it six times for each microsecond of
-    // delay requested.
-    us *= 6; // x6 us, = 7 cycles
+  // the following loop takes a 1/6 of a microsecond (4 cycles)
+  // per iteration, so execute it six times for each microsecond of
+  // delay requested.
+  us *= 6; // x6 us, = 7 cycles
 
-    // account for the time taken in the preceeding commands.
-    // we just burned 22 (24) cycles above, remove 5, (5*4=20)
-    // us is at least 6 so we can substract 5
-    us -= 5; //=2 cycles
+  // account for the time taken in the preceeding commands.
+  // we just burned 22 (24) cycles above, remove 5, (5*4=20)
+  // us is at least 6 so we can substract 5
+  us -= 5; //=2 cycles
 
 #elif F_CPU >= 20000000L
-    // for the 20 MHz clock on rare Arduino boards
+  // for the 20 MHz clock on rare Arduino boards
 
-    // for a one-microsecond delay, simply return.  the overhead
-    // of the function call takes 18 (20) cycles, which is 1us
-    __asm__ __volatile__(
-        "nop" "\n\t"
-        "nop" "\n\t"
-        "nop" "\n\t"
-        "nop"); //just waiting 4 cycles
-    if (us <= 1) return; //  = 3 cycles, (4 when true)
+  // for a one-microsecond delay, simply return.  the overhead
+  // of the function call takes 18 (20) cycles, which is 1us
+  __asm__ __volatile__ (
+    "nop" "\n\t"
+    "nop" "\n\t"
+    "nop" "\n\t"
+    "nop"); //just waiting 4 cycles
+  if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-    // the following loop takes a 1/5 of a microsecond (4 cycles)
-    // per iteration, so execute it five times for each microsecond of
-    // delay requested.
-    us = (us << 2) + us; // x5 us, = 7 cycles
+  // the following loop takes a 1/5 of a microsecond (4 cycles)
+  // per iteration, so execute it five times for each microsecond of
+  // delay requested.
+  us = (us << 2) + us; // x5 us, = 7 cycles
 
-    // account for the time taken in the preceeding commands.
-    // we just burned 26 (28) cycles above, remove 7, (7*4=28)
-    // us is at least 10 so we can substract 7
-    us -= 7; // 2 cycles
+  // account for the time taken in the preceeding commands.
+  // we just burned 26 (28) cycles above, remove 7, (7*4=28)
+  // us is at least 10 so we can substract 7
+  us -= 7; // 2 cycles
 
 #elif F_CPU >= 16000000L
-    // for the 16 MHz clock on most Arduino boards
+  // for the 16 MHz clock on most Arduino boards
 
-    // for a one-microsecond delay, simply return.  the overhead
-    // of the function call takes 14 (16) cycles, which is 1us
-    if (us <= 1) return; //  = 3 cycles, (4 when true)
+  // for a one-microsecond delay, simply return.  the overhead
+  // of the function call takes 14 (16) cycles, which is 1us
+  if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-    // the following loop takes 1/4 of a microsecond (4 cycles)
-    // per iteration, so execute it four times for each microsecond of
-    // delay requested.
-    us <<= 2; // x4 us, = 4 cycles
+  // the following loop takes 1/4 of a microsecond (4 cycles)
+  // per iteration, so execute it four times for each microsecond of
+  // delay requested.
+  us <<= 2; // x4 us, = 4 cycles
 
-    // account for the time taken in the preceeding commands.
-    // we just burned 19 (21) cycles above, remove 5, (5*4=20)
-    // us is at least 8 so we can substract 5
-    us -= 5; // = 2 cycles,
+  // account for the time taken in the preceeding commands.
+  // we just burned 19 (21) cycles above, remove 5, (5*4=20)
+  // us is at least 8 so we can substract 5
+  us -= 5; // = 2 cycles,
 
 #elif F_CPU >= 12000000L
-    // for the 12 MHz clock if somebody is working with USB
+  // for the 12 MHz clock if somebody is working with USB
 
-    // for a 1 microsecond delay, simply return.  the overhead
-    // of the function call takes 14 (16) cycles, which is 1.5us
-    if (us <= 1) return; //  = 3 cycles, (4 when true)
+  // for a 1 microsecond delay, simply return.  the overhead
+  // of the function call takes 14 (16) cycles, which is 1.5us
+  if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-    // the following loop takes 1/3 of a microsecond (4 cycles)
-    // per iteration, so execute it three times for each microsecond of
-    // delay requested.
-    us = (us << 1) + us; // x3 us, = 5 cycles
+  // the following loop takes 1/3 of a microsecond (4 cycles)
+  // per iteration, so execute it three times for each microsecond of
+  // delay requested.
+  us = (us << 1) + us; // x3 us, = 5 cycles
 
-    // account for the time taken in the preceeding commands.
-    // we just burned 20 (22) cycles above, remove 5, (5*4=20)
-    // us is at least 6 so we can substract 5
-    us -= 5; //2 cycles
+  // account for the time taken in the preceeding commands.
+  // we just burned 20 (22) cycles above, remove 5, (5*4=20)
+  // us is at least 6 so we can substract 5
+  us -= 5; //2 cycles
 
 #elif F_CPU >= 8000000L
-    // for the 8 MHz internal clock
+  // for the 8 MHz internal clock
 
-    // for a 1 and 2 microsecond delay, simply return.  the overhead
-    // of the function call takes 14 (16) cycles, which is 2us
-    if (us <= 2) return; //  = 3 cycles, (4 when true)
+  // for a 1 and 2 microsecond delay, simply return.  the overhead
+  // of the function call takes 14 (16) cycles, which is 2us
+  if (us <= 2) return; //  = 3 cycles, (4 when true)
 
-    // the following loop takes 1/2 of a microsecond (4 cycles)
-    // per iteration, so execute it twice for each microsecond of
-    // delay requested.
-    us <<= 1; //x2 us, = 2 cycles
+  // the following loop takes 1/2 of a microsecond (4 cycles)
+  // per iteration, so execute it twice for each microsecond of
+  // delay requested.
+  us <<= 1; //x2 us, = 2 cycles
 
-    // account for the time taken in the preceeding commands.
-    // we just burned 17 (19) cycles above, remove 4, (4*4=16)
-    // us is at least 6 so we can substract 4
-    us -= 4; // = 2 cycles
+  // account for the time taken in the preceeding commands.
+  // we just burned 17 (19) cycles above, remove 4, (4*4=16)
+  // us is at least 6 so we can substract 4
+  us -= 4; // = 2 cycles
 
 #else
-    // for the 1 MHz internal clock (default settings for common Atmega microcontrollers)
+  // for the 1 MHz internal clock (default settings for common Atmega microcontrollers)
 
-    // the overhead of the function calls is 14 (16) cycles
-    if (us <= 16) return; //= 3 cycles, (4 when true)
-    if (us <= 25) return; //= 3 cycles, (4 when true), (must be at least 25 if we want to substract 22)
+  // the overhead of the function calls is 14 (16) cycles
+  if (us <= 16) return; //= 3 cycles, (4 when true)
+  if (us <= 25) return; //= 3 cycles, (4 when true), (must be at least 25 if we want to substract 22)
 
-    // compensate for the time taken by the preceeding and next commands (about 22 cycles)
-    us -= 22; // = 2 cycles
-    // the following loop takes 4 microseconds (4 cycles)
-    // per iteration, so execute it us/4 times
-    // us is at least 4, divided by 4 gives us 1 (no zero delay bug)
-    us >>= 2; // us div 4, = 4 cycles
-
+  // compensate for the time taken by the preceeding and next commands (about 22 cycles)
+  us -= 22; // = 2 cycles
+  // the following loop takes 4 microseconds (4 cycles)
+  // per iteration, so execute it us/4 times
+  // us is at least 4, divided by 4 gives us 1 (no zero delay bug)
+  us >>= 2; // us div 4, = 4 cycles
+  
 
 #endif
 
-    // busy wait
-    __asm__ __volatile__(
-        "1: sbiw %0,1" "\n\t" // 2 cycles
-        "brne 1b" : "=w" (us) : "0" (us) // 2 cycles
-    );
-    // return = 4 cycles
+  // busy wait
+  __asm__ __volatile__ (
+    "1: sbiw %0,1" "\n\t" // 2 cycles
+    "brne 1b" : "=w" (us) : "0" (us) // 2 cycles
+  );
+  // return = 4 cycles
 }
 
 void init()
 {
-    // this needs to be called before setup() or some functions won't
-    // work there
-    sei();
-
-    // on the ATmega168, timer 0 is also used for fast hardware pwm
-    // (using phase-correct PWM would mean that timer 0 overflowed half as often
-    // resulting in different millis() behavior on the ATmega8 and ATmega168)
+  // this needs to be called before setup() or some functions won't
+  // work there
+  sei();
+  
+  // on the ATmega168, timer 0 is also used for fast hardware pwm
+  // (using phase-correct PWM would mean that timer 0 overflowed half as often
+  // resulting in different millis() behavior on the ATmega8 and ATmega168)
 #if defined(TCCR0A) && defined(WGM01)
-    sbi(TCCR0A, WGM01);
-    sbi(TCCR0A, WGM00);
+  sbi(TCCR0A, WGM01);
+  sbi(TCCR0A, WGM00);
 #endif
 
-    // set timer 0 prescale factor to 64
+  // set timer 0 prescale factor to 64
 #if defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
-    // CPU specific: different values for the ATmega64/128
-    sbi(TCCR0, WGM00);
-    sbi(TCCR0, WGM01);
-    sbi(TCCR0, CS02);
+  // CPU specific: different values for the ATmega64/128
+  sbi(TCCR0, WGM00);
+  sbi(TCCR0, WGM01);
+  sbi(TCCR0, CS02);
 #elif defined(TCCR0) && defined(CS01) && defined(CS00)
-    // this combination is for the ATmega8535, ATmega8, ATmega16, ATmega32, ATmega8515, ATmega162
-    sbi(TCCR0, CS01);
-    sbi(TCCR0, CS00);
-#if defined(WGM00) && defined(WGM01) // The ATmega8 doesn't have WGM00 and WGM01
+  // this combination is for the ATmega8535, ATmega8, ATmega16, ATmega32, ATmega8515, ATmega162
+  sbi(TCCR0, CS01);
+  sbi(TCCR0, CS00);
+    #if defined(WGM00) && defined(WGM01) // The ATmega8 doesn't have WGM00 and WGM01
     sbi(TCCR0, WGM00);
     sbi(TCCR0, WGM01);
-#endif
+  #endif
 #elif defined(TCCR0B) && defined(CS01) && defined(CS00)
-    // this combination is for the standard 168/328/640/1280/1281/2560/2561
-    sbi(TCCR0B, CS01);
-    sbi(TCCR0B, CS00);
+  // this combination is for the standard 168/328/640/1280/1281/2560/2561
+  sbi(TCCR0B, CS01);
+  sbi(TCCR0B, CS00);
 #elif defined(TCCR0A) && defined(CS01) && defined(CS00)
-    // this combination is for the __AVR_ATmega645__ series
-    sbi(TCCR0A, CS01);
-    sbi(TCCR0A, CS00);
+  // this combination is for the __AVR_ATmega645__ series
+  sbi(TCCR0A, CS01);
+  sbi(TCCR0A, CS00);
 #else
-#error Timer 0 prescale factor 64 not set correctly
+  #error Timer 0 prescale factor 64 not set correctly
 #endif
 
-    // enable timer 0 overflow interrupt
+  // enable timer 0 overflow interrupt
 #if defined(TIMSK) && defined(TOIE0)
-    sbi(TIMSK, TOIE0);
+  sbi(TIMSK, TOIE0);
 #elif defined(TIMSK0) && defined(TOIE0)
-    sbi(TIMSK0, TOIE0);
+  sbi(TIMSK0, TOIE0);
 #else
-#error  Timer 0 overflow interrupt not set correctly
+  #error  Timer 0 overflow interrupt not set correctly
 #endif
 
-    // timers 1 and 2 are used for phase-correct hardware pwm
-    // this is better for motors as it ensures an even waveform
-    // note, however, that fast pwm mode can achieve a frequency of up
-    // 8 MHz (with a 16 MHz clock) at 50% duty cycle
+  // timers 1 and 2 are used for phase-correct hardware pwm
+  // this is better for motors as it ensures an even waveform
+  // note, however, that fast pwm mode can achieve a frequency of up
+  // 8 MHz (with a 16 MHz clock) at 50% duty cycle
 
 #if defined(TCCR1B) && defined(CS11) && defined(CS10)
-    TCCR1B = 0;
+  TCCR1B = 0;
 
-    // set timer 1 prescale factor to 64
-    sbi(TCCR1B, CS11);
+  // set timer 1 prescale factor to 64
+  sbi(TCCR1B, CS11);
 #if F_CPU >= 8000000L
-    sbi(TCCR1B, CS10);
+  sbi(TCCR1B, CS10);
 #endif
 #elif defined(TCCR1) && defined(CS11) && defined(CS10)
-    sbi(TCCR1, CS11);
+  sbi(TCCR1, CS11);
 #if F_CPU >= 8000000L
-    sbi(TCCR1, CS10);
+  sbi(TCCR1, CS10);
 #endif
 #endif
-    // put timer 1 in 8-bit phase correct pwm mode
+  // put timer 1 in 8-bit phase correct pwm mode
 #if defined(TCCR1A) && defined(WGM10)
-    sbi(TCCR1A, WGM10);
+  sbi(TCCR1A, WGM10);
 #endif
 
-    // set timer 2 prescale factor to 64
+  // set timer 2 prescale factor to 64
 #if defined(TCCR2) && defined(CS22)
-    sbi(TCCR2, CS22);
+  sbi(TCCR2, CS22);
 #elif defined(TCCR2B) && defined(CS22)
-    sbi(TCCR2B, CS22);
-    //#else
-        // Timer 2 not finished (may not be present on this CPU)
+  sbi(TCCR2B, CS22);
+//#else
+  // Timer 2 not finished (may not be present on this CPU)
 #endif
 
-    // configure timer 2 for phase correct pwm (8-bit)
+  // configure timer 2 for phase correct pwm (8-bit)
 #if defined(TCCR2) && defined(WGM20)
-    sbi(TCCR2, WGM20);
+  sbi(TCCR2, WGM20);
 #elif defined(TCCR2A) && defined(WGM20)
-    sbi(TCCR2A, WGM20);
-    //#else
-        // Timer 2 not finished (may not be present on this CPU)
+  sbi(TCCR2A, WGM20);
+//#else
+  // Timer 2 not finished (may not be present on this CPU)
 #endif
 
 #if defined(TCCR3B) && defined(CS31) && defined(WGM30)
-    sbi(TCCR3B, CS31);      // set timer 3 prescale factor to 64
-    sbi(TCCR3B, CS30);
-    sbi(TCCR3A, WGM30);     // put timer 3 in 8-bit phase correct pwm mode
+  sbi(TCCR3B, CS31);    // set timer 3 prescale factor to 64
+  sbi(TCCR3B, CS30);
+  sbi(TCCR3A, WGM30);   // put timer 3 in 8-bit phase correct pwm mode
 #endif
 
 #if defined(TCCR4A) && defined(TCCR4B) && defined(TCCR4D) /* beginning of timer4 block for 32U4 and similar */
-    sbi(TCCR4B, CS42);      // set timer4 prescale factor to 64
-    sbi(TCCR4B, CS41);
-    sbi(TCCR4B, CS40);
-    sbi(TCCR4D, WGM40);     // put timer 4 in phase- and frequency-correct PWM mode 
-    sbi(TCCR4A, PWM4A);     // enable PWM mode for comparator OCR4A
-    sbi(TCCR4C, PWM4D);     // enable PWM mode for comparator OCR4D
+  sbi(TCCR4B, CS42);    // set timer4 prescale factor to 64
+  sbi(TCCR4B, CS41);
+  sbi(TCCR4B, CS40);
+  sbi(TCCR4D, WGM40);   // put timer 4 in phase- and frequency-correct PWM mode 
+  sbi(TCCR4A, PWM4A);   // enable PWM mode for comparator OCR4A
+  sbi(TCCR4C, PWM4D);   // enable PWM mode for comparator OCR4D
 #else /* beginning of timer4 block for ATMEGA640, ATMEGA1280 and ATMEGA2560 */
 #if defined(TCCR4B) && defined(CS41) && defined(WGM40)
-    sbi(TCCR4B, CS41);      // set timer 4 prescale factor to 64
-    sbi(TCCR4B, CS40);
-    sbi(TCCR4A, WGM40);     // put timer 4 in 8-bit phase correct pwm mode
+  sbi(TCCR4B, CS41);    // set timer 4 prescale factor to 64
+  sbi(TCCR4B, CS40);
+  sbi(TCCR4A, WGM40);   // put timer 4 in 8-bit phase correct pwm mode
 #endif
-#endif /* end timer4 block for ATMEGA640/1280/2560 and similar */   
+#endif /* end timer4 block for ATMEGA640/1280/2560 and similar */ 
 
 #if defined(TCCR5B) && defined(CS51) && defined(WGM50)
-    sbi(TCCR5B, CS51);      // set timer 5 prescale factor to 64
-    sbi(TCCR5B, CS50);
-    sbi(TCCR5A, WGM50);     // put timer 5 in 8-bit phase correct pwm mode
+  sbi(TCCR5B, CS51);    // set timer 5 prescale factor to 64
+  sbi(TCCR5B, CS50);
+  sbi(TCCR5A, WGM50);   // put timer 5 in 8-bit phase correct pwm mode
 #endif
 
 #if defined(ADCSRA)
-    // set a2d prescaler so we are inside the desired 50-200 KHz range.
-#if F_CPU >= 16000000 // 16 MHz / 128 = 125 KHz
+  // set a2d prescaler so we are inside the desired 50-200 KHz range.
+  #if F_CPU >= 16000000 // 16 MHz / 128 = 125 KHz
     sbi(ADCSRA, ADPS2);
     sbi(ADCSRA, ADPS1);
     sbi(ADCSRA, ADPS0);
-#elif F_CPU >= 8000000 // 8 MHz / 64 = 125 KHz
+  #elif F_CPU >= 8000000 // 8 MHz / 64 = 125 KHz
     sbi(ADCSRA, ADPS2);
     sbi(ADCSRA, ADPS1);
     cbi(ADCSRA, ADPS0);
-#elif F_CPU >= 4000000 // 4 MHz / 32 = 125 KHz
+  #elif F_CPU >= 4000000 // 4 MHz / 32 = 125 KHz
     sbi(ADCSRA, ADPS2);
     cbi(ADCSRA, ADPS1);
     sbi(ADCSRA, ADPS0);
-#elif F_CPU >= 2000000 // 2 MHz / 16 = 125 KHz
+  #elif F_CPU >= 2000000 // 2 MHz / 16 = 125 KHz
     sbi(ADCSRA, ADPS2);
     cbi(ADCSRA, ADPS1);
     cbi(ADCSRA, ADPS0);
-#elif F_CPU >= 1000000 // 1 MHz / 8 = 125 KHz
+  #elif F_CPU >= 1000000 // 1 MHz / 8 = 125 KHz
     cbi(ADCSRA, ADPS2);
     sbi(ADCSRA, ADPS1);
     sbi(ADCSRA, ADPS0);
-#else // 128 kHz / 2 = 64 KHz -> This is the closest you can get, the prescaler is 2
+  #else // 128 kHz / 2 = 64 KHz -> This is the closest you can get, the prescaler is 2
     cbi(ADCSRA, ADPS2);
     cbi(ADCSRA, ADPS1);
     sbi(ADCSRA, ADPS0);
-#endif
-    // enable a2d conversions
-    sbi(ADCSRA, ADEN);
+  #endif
+  // enable a2d conversions
+  sbi(ADCSRA, ADEN);
 #endif
 
-    // the bootloader connects pins 0 and 1 to the USART; disconnect them
-    // here so they can be used as normal digital i/o; they will be
-    // reconnected in Serial.begin()
+  // the bootloader connects pins 0 and 1 to the USART; disconnect them
+  // here so they can be used as normal digital i/o; they will be
+  // reconnected in Serial.begin()
 #if defined(UCSRB)
-    UCSRB = 0;
+  UCSRB = 0;
 #elif defined(UCSR0B)
-    UCSR0B = 0;
+  UCSR0B = 0;
 #endif
 }

--- a/wiring.c
+++ b/wiring.c
@@ -112,7 +112,6 @@ unsigned long micros() {
     if ((TIFR & _BV(TOV0)) && (t < 255))
         m++;
 #endif
-
     // Restore SREG
     SREG = oldSREG;
 
@@ -123,10 +122,8 @@ unsigned long micros() {
 
     // Multiply m by 256 (to fit t) and add t
     m = (m << 8) + t;
-
     return m + (m << 1) + (m >> 2) - (m >> 4);
 #else
-
     // Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 
     // m is multiplied by 4 (since it was already multiplied by 256)
     // t is multiplied by 4

--- a/wiring.c
+++ b/wiring.c
@@ -24,378 +24,417 @@
 
 // the prescaler is set so that timer0 ticks every 64 clock cycles, and the
 // the overflow handler is called every 256 ticks.
+// 20MHz: An overflow happens every  819.2  microseconds    --->     0,05 (time of a cycle) * 64 (timer0 tick) * 256 (every 256 ticks timer0 overflows), so this results in 819
+// 16MHz: An overflow happens every 1024 microseconds
 #define MICROSECONDS_PER_TIMER0_OVERFLOW (clockCyclesToMicroseconds(64 * 256))
 
 // the whole number of milliseconds per timer0 overflow
+// For 20MHz this would be 0 (because 819)
+// For 16MHz this would be 1 (because 1024)
 #define MILLIS_INC (MICROSECONDS_PER_TIMER0_OVERFLOW / 1000)
 
 // the fractional number of milliseconds per timer0 overflow. we shift right
 // by three to fit these numbers into a byte. (for the clock speeds we care
 // about - 8 and 16 MHz - this doesn't lose precision.)
+// For 16 MHz: 24 (1024 % 1000) gets shiftet right by 3 which results in 3
+// For 20MHz 819 (819 % 1000) gets shiftet right by 3 which results in 102 (precision was lost)
 #define FRACT_INC ((MICROSECONDS_PER_TIMER0_OVERFLOW % 1000) >> 3)
+
+// 1000 shift by 3 (to fit it in a byte) to the right is 125 (no precision lost) 
 #define FRACT_MAX (1000 >> 3)
 
+// 1000 shift by 2 (to fit in a byte) to the right is 250 (no precision lost)
+#define FRACT_MAX (1000 >> 2)
+
+
 volatile unsigned long timer0_overflow_count = 0;
+
 volatile unsigned long timer0_millis = 0;
 static unsigned char timer0_fract = 0;
 
+
+// timer0 interrupt routine ,- is called every time timer0 overflows
 #if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
 ISR(TIM0_OVF_vect)
 #else
 ISR(TIMER0_OVF_vect)
 #endif
 {
-  // copy these to local variables so they can be stored in registers
-  // (volatile variables must be read from memory on every access)
-  unsigned long m = timer0_millis;
-  unsigned char f = timer0_fract;
+	// copy these to local variables so they can be stored in registers
+	// (volatile variables must be read from memory on every access, so this saves time)
+	unsigned long m = timer0_millis;
+	unsigned char f = timer0_fract;
 
-  m += MILLIS_INC;
-  f += FRACT_INC;
-  if (f >= FRACT_MAX) {
-    f -= FRACT_MAX;
-    m += 1;
-  }
+	m += MILLIS_INC;
+	f += FRACT_INC;
+	if (f >= FRACT_MAX) {
+		f -= FRACT_MAX;
+		m += 1;
+	}
 
-  timer0_fract = f;
-  timer0_millis = m;
-  timer0_overflow_count++;
+	timer0_fract = f;
+	timer0_millis = m;
+	
+	// Since this function was called, timer0 overflowed
+	timer0_overflow_count++;
 }
 
+
+
+// 
 unsigned long millis()
 {
-  unsigned long m;
-  uint8_t oldSREG = SREG;
+	unsigned long m;
+	uint8_t oldSREG = SREG;
 
-  // disable interrupts while we read timer0_millis or we might get an
-  // inconsistent value (e.g. in the middle of a write to timer0_millis)
-  cli();
-  m = timer0_millis;
-  SREG = oldSREG;
+	// disable interrupts while we read timer0_millis or we might get an
+	// inconsistent value (e.g. in the middle of a write to timer0_millis)
+	cli();
+	m = timer0_millis;
+	SREG = oldSREG;
 
-  return m;
+	return m;
 }
 
 unsigned long micros() {
-  unsigned long m;
-  uint8_t oldSREG = SREG, t;
-  
-  cli();
-  m = timer0_overflow_count;
+	unsigned long m;
+	uint8_t oldSREG = SREG;
+	
+	// t will be the number where the timer0 counter stopped
+	uint8_t t;
+	
+	// Stop all interrupts
+	cli();
+	
+	m = timer0_overflow_count;
+	
+	// TCNT0 ist the Timer Counter Register
 #if defined(TCNT0)
-  t = TCNT0;
+	t = TCNT0;
 #elif defined(TCNT0L)
-  t = TCNT0L;
+	t = TCNT0L;
 #else
-  #error TIMER 0 not defined
+	#error TIMER 0 not defined
 #endif
 
+// Timer0 Interrupt Flag Register
 #ifdef TIFR0
-  if ((TIFR0 & _BV(TOV0)) && (t < 255))
-    m++;
+	if ((TIFR0 & _BV(TOV0)) && (t < 255))
+		m++;
 #else
-  if ((TIFR & _BV(TOV0)) && (t < 255))
-    m++;
+	if ((TIFR & _BV(TOV0)) && (t < 255))
+		m++;
 #endif
 
-  SREG = oldSREG;
-#if F_CPU == 20000000L
-  
+	// Restore SREG
+	SREG = oldSREG;
+	
+#if F_CPU >= 20000000L
+
+// m needs to be multiplied by 819,2 
+// t needs to be multiplied by 3,2
+// then add m and t
+// TODO:
+  return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 #else
+
+  // Shift by 8 to the left (multiply by 256) so t (which is 1 byte in size) can fit in 
+  // m is multiplied by 4 (since it was already multiplied by 256)
+  // t is multiplied by 4
   return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 #endif
 }
 
 void delay(unsigned long ms)
 {
-  uint32_t start = micros();
+	uint32_t start = micros();
 
-  while (ms > 0) {
-    yield();
-    while ( ms > 0 && (micros() - start) >= 1000) {
-      ms--;
-      start += 1000;
-    }
-  }
+	while (ms > 0) {
+		yield();
+		while ( ms > 0 && (micros() - start) >= 1000) {
+			ms--;
+			start += 1000;
+		}
+	}
 }
 
 /* Delay for the given number of microseconds.  Assumes a 1, 8, 12, 16, 20 or 24 MHz clock. */
 void delayMicroseconds(unsigned int us)
 {
-  // call = 4 cycles + 2 to 4 cycles to init us(2 for constant delay, 4 for variable)
+	// call = 4 cycles + 2 to 4 cycles to init us(2 for constant delay, 4 for variable)
 
-  // calling avrlib's delay_us() function with low values (e.g. 1 or
-  // 2 microseconds) gives delays longer than desired.
-  //delay_us(us);
+	// calling avrlib's delay_us() function with low values (e.g. 1 or
+	// 2 microseconds) gives delays longer than desired.
+	//delay_us(us);
 #if F_CPU >= 24000000L
-  // for the 24 MHz clock for the aventurous ones, trying to overclock
+	// for the 24 MHz clock for the aventurous ones, trying to overclock
 
-  // zero delay fix
-  if (!us) return; //  = 3 cycles, (4 when true)
+	// zero delay fix
+	if (!us) return; //  = 3 cycles, (4 when true)
 
-  // the following loop takes a 1/6 of a microsecond (4 cycles)
-  // per iteration, so execute it six times for each microsecond of
-  // delay requested.
-  us *= 6; // x6 us, = 7 cycles
+	// the following loop takes a 1/6 of a microsecond (4 cycles)
+	// per iteration, so execute it six times for each microsecond of
+	// delay requested.
+	us *= 6; // x6 us, = 7 cycles
 
-  // account for the time taken in the preceeding commands.
-  // we just burned 22 (24) cycles above, remove 5, (5*4=20)
-  // us is at least 6 so we can substract 5
-  us -= 5; //=2 cycles
+	// account for the time taken in the preceeding commands.
+	// we just burned 22 (24) cycles above, remove 5, (5*4=20)
+	// us is at least 6 so we can substract 5
+	us -= 5; //=2 cycles
 
 #elif F_CPU >= 20000000L
-  // for the 20 MHz clock on rare Arduino boards
+	// for the 20 MHz clock on rare Arduino boards
 
-  // for a one-microsecond delay, simply return.  the overhead
-  // of the function call takes 18 (20) cycles, which is 1us
-  __asm__ __volatile__ (
-    "nop" "\n\t"
-    "nop" "\n\t"
-    "nop" "\n\t"
-    "nop"); //just waiting 4 cycles
-  if (us <= 1) return; //  = 3 cycles, (4 when true)
+	// for a one-microsecond delay, simply return.  the overhead
+	// of the function call takes 18 (20) cycles, which is 1us
+	__asm__ __volatile__ (
+		"nop" "\n\t"
+		"nop" "\n\t"
+		"nop" "\n\t"
+		"nop"); //just waiting 4 cycles
+	if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-  // the following loop takes a 1/5 of a microsecond (4 cycles)
-  // per iteration, so execute it five times for each microsecond of
-  // delay requested.
-  us = (us << 2) + us; // x5 us, = 7 cycles
+	// the following loop takes a 1/5 of a microsecond (4 cycles)
+	// per iteration, so execute it five times for each microsecond of
+	// delay requested.
+	us = (us << 2) + us; // x5 us, = 7 cycles
 
-  // account for the time taken in the preceeding commands.
-  // we just burned 26 (28) cycles above, remove 7, (7*4=28)
-  // us is at least 10 so we can substract 7
-  us -= 7; // 2 cycles
+	// account for the time taken in the preceeding commands.
+	// we just burned 26 (28) cycles above, remove 7, (7*4=28)
+	// us is at least 10 so we can substract 7
+	us -= 7; // 2 cycles
 
 #elif F_CPU >= 16000000L
-  // for the 16 MHz clock on most Arduino boards
+	// for the 16 MHz clock on most Arduino boards
 
-  // for a one-microsecond delay, simply return.  the overhead
-  // of the function call takes 14 (16) cycles, which is 1us
-  if (us <= 1) return; //  = 3 cycles, (4 when true)
+	// for a one-microsecond delay, simply return.  the overhead
+	// of the function call takes 14 (16) cycles, which is 1us
+	if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-  // the following loop takes 1/4 of a microsecond (4 cycles)
-  // per iteration, so execute it four times for each microsecond of
-  // delay requested.
-  us <<= 2; // x4 us, = 4 cycles
+	// the following loop takes 1/4 of a microsecond (4 cycles)
+	// per iteration, so execute it four times for each microsecond of
+	// delay requested.
+	us <<= 2; // x4 us, = 4 cycles
 
-  // account for the time taken in the preceeding commands.
-  // we just burned 19 (21) cycles above, remove 5, (5*4=20)
-  // us is at least 8 so we can substract 5
-  us -= 5; // = 2 cycles,
+	// account for the time taken in the preceeding commands.
+	// we just burned 19 (21) cycles above, remove 5, (5*4=20)
+	// us is at least 8 so we can substract 5
+	us -= 5; // = 2 cycles,
 
 #elif F_CPU >= 12000000L
-  // for the 12 MHz clock if somebody is working with USB
+	// for the 12 MHz clock if somebody is working with USB
 
-  // for a 1 microsecond delay, simply return.  the overhead
-  // of the function call takes 14 (16) cycles, which is 1.5us
-  if (us <= 1) return; //  = 3 cycles, (4 when true)
+	// for a 1 microsecond delay, simply return.  the overhead
+	// of the function call takes 14 (16) cycles, which is 1.5us
+	if (us <= 1) return; //  = 3 cycles, (4 when true)
 
-  // the following loop takes 1/3 of a microsecond (4 cycles)
-  // per iteration, so execute it three times for each microsecond of
-  // delay requested.
-  us = (us << 1) + us; // x3 us, = 5 cycles
+	// the following loop takes 1/3 of a microsecond (4 cycles)
+	// per iteration, so execute it three times for each microsecond of
+	// delay requested.
+	us = (us << 1) + us; // x3 us, = 5 cycles
 
-  // account for the time taken in the preceeding commands.
-  // we just burned 20 (22) cycles above, remove 5, (5*4=20)
-  // us is at least 6 so we can substract 5
-  us -= 5; //2 cycles
+	// account for the time taken in the preceeding commands.
+	// we just burned 20 (22) cycles above, remove 5, (5*4=20)
+	// us is at least 6 so we can substract 5
+	us -= 5; //2 cycles
 
 #elif F_CPU >= 8000000L
-  // for the 8 MHz internal clock
+	// for the 8 MHz internal clock
 
-  // for a 1 and 2 microsecond delay, simply return.  the overhead
-  // of the function call takes 14 (16) cycles, which is 2us
-  if (us <= 2) return; //  = 3 cycles, (4 when true)
+	// for a 1 and 2 microsecond delay, simply return.  the overhead
+	// of the function call takes 14 (16) cycles, which is 2us
+	if (us <= 2) return; //  = 3 cycles, (4 when true)
 
-  // the following loop takes 1/2 of a microsecond (4 cycles)
-  // per iteration, so execute it twice for each microsecond of
-  // delay requested.
-  us <<= 1; //x2 us, = 2 cycles
+	// the following loop takes 1/2 of a microsecond (4 cycles)
+	// per iteration, so execute it twice for each microsecond of
+	// delay requested.
+	us <<= 1; //x2 us, = 2 cycles
 
-  // account for the time taken in the preceeding commands.
-  // we just burned 17 (19) cycles above, remove 4, (4*4=16)
-  // us is at least 6 so we can substract 4
-  us -= 4; // = 2 cycles
+	// account for the time taken in the preceeding commands.
+	// we just burned 17 (19) cycles above, remove 4, (4*4=16)
+	// us is at least 6 so we can substract 4
+	us -= 4; // = 2 cycles
 
 #else
-  // for the 1 MHz internal clock (default settings for common Atmega microcontrollers)
+	// for the 1 MHz internal clock (default settings for common Atmega microcontrollers)
 
-  // the overhead of the function calls is 14 (16) cycles
-  if (us <= 16) return; //= 3 cycles, (4 when true)
-  if (us <= 25) return; //= 3 cycles, (4 when true), (must be at least 25 if we want to substract 22)
+	// the overhead of the function calls is 14 (16) cycles
+	if (us <= 16) return; //= 3 cycles, (4 when true)
+	if (us <= 25) return; //= 3 cycles, (4 when true), (must be at least 25 if we want to substract 22)
 
-  // compensate for the time taken by the preceeding and next commands (about 22 cycles)
-  us -= 22; // = 2 cycles
-  // the following loop takes 4 microseconds (4 cycles)
-  // per iteration, so execute it us/4 times
-  // us is at least 4, divided by 4 gives us 1 (no zero delay bug)
-  us >>= 2; // us div 4, = 4 cycles
-  
+	// compensate for the time taken by the preceeding and next commands (about 22 cycles)
+	us -= 22; // = 2 cycles
+	// the following loop takes 4 microseconds (4 cycles)
+	// per iteration, so execute it us/4 times
+	// us is at least 4, divided by 4 gives us 1 (no zero delay bug)
+	us >>= 2; // us div 4, = 4 cycles
+	
 
 #endif
 
-  // busy wait
-  __asm__ __volatile__ (
-    "1: sbiw %0,1" "\n\t" // 2 cycles
-    "brne 1b" : "=w" (us) : "0" (us) // 2 cycles
-  );
-  // return = 4 cycles
+	// busy wait
+	__asm__ __volatile__ (
+		"1: sbiw %0,1" "\n\t" // 2 cycles
+		"brne 1b" : "=w" (us) : "0" (us) // 2 cycles
+	);
+	// return = 4 cycles
 }
 
 void init()
 {
-  // this needs to be called before setup() or some functions won't
-  // work there
-  sei();
-  
-  // on the ATmega168, timer 0 is also used for fast hardware pwm
-  // (using phase-correct PWM would mean that timer 0 overflowed half as often
-  // resulting in different millis() behavior on the ATmega8 and ATmega168)
+	// this needs to be called before setup() or some functions won't
+	// work there
+	sei();
+	
+	// on the ATmega168, timer 0 is also used for fast hardware pwm
+	// (using phase-correct PWM would mean that timer 0 overflowed half as often
+	// resulting in different millis() behavior on the ATmega8 and ATmega168)
 #if defined(TCCR0A) && defined(WGM01)
-  sbi(TCCR0A, WGM01);
-  sbi(TCCR0A, WGM00);
+	sbi(TCCR0A, WGM01);
+	sbi(TCCR0A, WGM00);
 #endif
 
-  // set timer 0 prescale factor to 64
+	// set timer 0 prescale factor to 64
 #if defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
-  // CPU specific: different values for the ATmega64/128
-  sbi(TCCR0, WGM00);
-  sbi(TCCR0, WGM01);
-  sbi(TCCR0, CS02);
+	// CPU specific: different values for the ATmega64/128
+	sbi(TCCR0, WGM00);
+	sbi(TCCR0, WGM01);
+	sbi(TCCR0, CS02);
 #elif defined(TCCR0) && defined(CS01) && defined(CS00)
-  // this combination is for the ATmega8535, ATmega8, ATmega16, ATmega32, ATmega8515, ATmega162
-  sbi(TCCR0, CS01);
-  sbi(TCCR0, CS00);
-    #if defined(WGM00) && defined(WGM01) // The ATmega8 doesn't have WGM00 and WGM01
-    sbi(TCCR0, WGM00);
-    sbi(TCCR0, WGM01);
-  #endif
+	// this combination is for the ATmega8535, ATmega8, ATmega16, ATmega32, ATmega8515, ATmega162
+	sbi(TCCR0, CS01);
+	sbi(TCCR0, CS00);
+		#if defined(WGM00) && defined(WGM01) // The ATmega8 doesn't have WGM00 and WGM01
+	  sbi(TCCR0, WGM00);
+	  sbi(TCCR0, WGM01);
+	#endif
 #elif defined(TCCR0B) && defined(CS01) && defined(CS00)
-  // this combination is for the standard 168/328/640/1280/1281/2560/2561
-  sbi(TCCR0B, CS01);
-  sbi(TCCR0B, CS00);
+	// this combination is for the standard 168/328/640/1280/1281/2560/2561
+	sbi(TCCR0B, CS01);
+	sbi(TCCR0B, CS00);
 #elif defined(TCCR0A) && defined(CS01) && defined(CS00)
-  // this combination is for the __AVR_ATmega645__ series
-  sbi(TCCR0A, CS01);
-  sbi(TCCR0A, CS00);
+	// this combination is for the __AVR_ATmega645__ series
+	sbi(TCCR0A, CS01);
+	sbi(TCCR0A, CS00);
 #else
-  #error Timer 0 prescale factor 64 not set correctly
+	#error Timer 0 prescale factor 64 not set correctly
 #endif
 
-  // enable timer 0 overflow interrupt
+	// enable timer 0 overflow interrupt
 #if defined(TIMSK) && defined(TOIE0)
-  sbi(TIMSK, TOIE0);
+	sbi(TIMSK, TOIE0);
 #elif defined(TIMSK0) && defined(TOIE0)
-  sbi(TIMSK0, TOIE0);
+	sbi(TIMSK0, TOIE0);
 #else
-  #error  Timer 0 overflow interrupt not set correctly
+	#error	Timer 0 overflow interrupt not set correctly
 #endif
 
-  // timers 1 and 2 are used for phase-correct hardware pwm
-  // this is better for motors as it ensures an even waveform
-  // note, however, that fast pwm mode can achieve a frequency of up
-  // 8 MHz (with a 16 MHz clock) at 50% duty cycle
+	// timers 1 and 2 are used for phase-correct hardware pwm
+	// this is better for motors as it ensures an even waveform
+	// note, however, that fast pwm mode can achieve a frequency of up
+	// 8 MHz (with a 16 MHz clock) at 50% duty cycle
 
 #if defined(TCCR1B) && defined(CS11) && defined(CS10)
-  TCCR1B = 0;
+	TCCR1B = 0;
 
-  // set timer 1 prescale factor to 64
-  sbi(TCCR1B, CS11);
+	// set timer 1 prescale factor to 64
+	sbi(TCCR1B, CS11);
 #if F_CPU >= 8000000L
-  sbi(TCCR1B, CS10);
+	sbi(TCCR1B, CS10);
 #endif
 #elif defined(TCCR1) && defined(CS11) && defined(CS10)
-  sbi(TCCR1, CS11);
+	sbi(TCCR1, CS11);
 #if F_CPU >= 8000000L
-  sbi(TCCR1, CS10);
+	sbi(TCCR1, CS10);
 #endif
 #endif
-  // put timer 1 in 8-bit phase correct pwm mode
+	// put timer 1 in 8-bit phase correct pwm mode
 #if defined(TCCR1A) && defined(WGM10)
-  sbi(TCCR1A, WGM10);
+	sbi(TCCR1A, WGM10);
 #endif
 
-  // set timer 2 prescale factor to 64
+	// set timer 2 prescale factor to 64
 #if defined(TCCR2) && defined(CS22)
-  sbi(TCCR2, CS22);
+	sbi(TCCR2, CS22);
 #elif defined(TCCR2B) && defined(CS22)
-  sbi(TCCR2B, CS22);
+	sbi(TCCR2B, CS22);
 //#else
-  // Timer 2 not finished (may not be present on this CPU)
+	// Timer 2 not finished (may not be present on this CPU)
 #endif
 
-  // configure timer 2 for phase correct pwm (8-bit)
+	// configure timer 2 for phase correct pwm (8-bit)
 #if defined(TCCR2) && defined(WGM20)
-  sbi(TCCR2, WGM20);
+	sbi(TCCR2, WGM20);
 #elif defined(TCCR2A) && defined(WGM20)
-  sbi(TCCR2A, WGM20);
+	sbi(TCCR2A, WGM20);
 //#else
-  // Timer 2 not finished (may not be present on this CPU)
+	// Timer 2 not finished (may not be present on this CPU)
 #endif
 
 #if defined(TCCR3B) && defined(CS31) && defined(WGM30)
-  sbi(TCCR3B, CS31);    // set timer 3 prescale factor to 64
-  sbi(TCCR3B, CS30);
-  sbi(TCCR3A, WGM30);   // put timer 3 in 8-bit phase correct pwm mode
+	sbi(TCCR3B, CS31);		// set timer 3 prescale factor to 64
+	sbi(TCCR3B, CS30);
+	sbi(TCCR3A, WGM30);		// put timer 3 in 8-bit phase correct pwm mode
 #endif
 
 #if defined(TCCR4A) && defined(TCCR4B) && defined(TCCR4D) /* beginning of timer4 block for 32U4 and similar */
-  sbi(TCCR4B, CS42);    // set timer4 prescale factor to 64
-  sbi(TCCR4B, CS41);
-  sbi(TCCR4B, CS40);
-  sbi(TCCR4D, WGM40);   // put timer 4 in phase- and frequency-correct PWM mode 
-  sbi(TCCR4A, PWM4A);   // enable PWM mode for comparator OCR4A
-  sbi(TCCR4C, PWM4D);   // enable PWM mode for comparator OCR4D
+	sbi(TCCR4B, CS42);		// set timer4 prescale factor to 64
+	sbi(TCCR4B, CS41);
+	sbi(TCCR4B, CS40);
+	sbi(TCCR4D, WGM40);		// put timer 4 in phase- and frequency-correct PWM mode	
+	sbi(TCCR4A, PWM4A);		// enable PWM mode for comparator OCR4A
+	sbi(TCCR4C, PWM4D);		// enable PWM mode for comparator OCR4D
 #else /* beginning of timer4 block for ATMEGA640, ATMEGA1280 and ATMEGA2560 */
 #if defined(TCCR4B) && defined(CS41) && defined(WGM40)
-  sbi(TCCR4B, CS41);    // set timer 4 prescale factor to 64
-  sbi(TCCR4B, CS40);
-  sbi(TCCR4A, WGM40);   // put timer 4 in 8-bit phase correct pwm mode
+	sbi(TCCR4B, CS41);		// set timer 4 prescale factor to 64
+	sbi(TCCR4B, CS40);
+	sbi(TCCR4A, WGM40);		// put timer 4 in 8-bit phase correct pwm mode
 #endif
-#endif /* end timer4 block for ATMEGA640/1280/2560 and similar */ 
+#endif /* end timer4 block for ATMEGA640/1280/2560 and similar */	
 
 #if defined(TCCR5B) && defined(CS51) && defined(WGM50)
-  sbi(TCCR5B, CS51);    // set timer 5 prescale factor to 64
-  sbi(TCCR5B, CS50);
-  sbi(TCCR5A, WGM50);   // put timer 5 in 8-bit phase correct pwm mode
+	sbi(TCCR5B, CS51);		// set timer 5 prescale factor to 64
+	sbi(TCCR5B, CS50);
+	sbi(TCCR5A, WGM50);		// put timer 5 in 8-bit phase correct pwm mode
 #endif
 
 #if defined(ADCSRA)
-  // set a2d prescaler so we are inside the desired 50-200 KHz range.
-  #if F_CPU >= 16000000 // 16 MHz / 128 = 125 KHz
-    sbi(ADCSRA, ADPS2);
-    sbi(ADCSRA, ADPS1);
-    sbi(ADCSRA, ADPS0);
-  #elif F_CPU >= 8000000 // 8 MHz / 64 = 125 KHz
-    sbi(ADCSRA, ADPS2);
-    sbi(ADCSRA, ADPS1);
-    cbi(ADCSRA, ADPS0);
-  #elif F_CPU >= 4000000 // 4 MHz / 32 = 125 KHz
-    sbi(ADCSRA, ADPS2);
-    cbi(ADCSRA, ADPS1);
-    sbi(ADCSRA, ADPS0);
-  #elif F_CPU >= 2000000 // 2 MHz / 16 = 125 KHz
-    sbi(ADCSRA, ADPS2);
-    cbi(ADCSRA, ADPS1);
-    cbi(ADCSRA, ADPS0);
-  #elif F_CPU >= 1000000 // 1 MHz / 8 = 125 KHz
-    cbi(ADCSRA, ADPS2);
-    sbi(ADCSRA, ADPS1);
-    sbi(ADCSRA, ADPS0);
-  #else // 128 kHz / 2 = 64 KHz -> This is the closest you can get, the prescaler is 2
-    cbi(ADCSRA, ADPS2);
-    cbi(ADCSRA, ADPS1);
-    sbi(ADCSRA, ADPS0);
-  #endif
-  // enable a2d conversions
-  sbi(ADCSRA, ADEN);
+	// set a2d prescaler so we are inside the desired 50-200 KHz range.
+	#if F_CPU >= 16000000 // 16 MHz / 128 = 125 KHz
+		sbi(ADCSRA, ADPS2);
+		sbi(ADCSRA, ADPS1);
+		sbi(ADCSRA, ADPS0);
+	#elif F_CPU >= 8000000 // 8 MHz / 64 = 125 KHz
+		sbi(ADCSRA, ADPS2);
+		sbi(ADCSRA, ADPS1);
+		cbi(ADCSRA, ADPS0);
+	#elif F_CPU >= 4000000 // 4 MHz / 32 = 125 KHz
+		sbi(ADCSRA, ADPS2);
+		cbi(ADCSRA, ADPS1);
+		sbi(ADCSRA, ADPS0);
+	#elif F_CPU >= 2000000 // 2 MHz / 16 = 125 KHz
+		sbi(ADCSRA, ADPS2);
+		cbi(ADCSRA, ADPS1);
+		cbi(ADCSRA, ADPS0);
+	#elif F_CPU >= 1000000 // 1 MHz / 8 = 125 KHz
+		cbi(ADCSRA, ADPS2);
+		sbi(ADCSRA, ADPS1);
+		sbi(ADCSRA, ADPS0);
+	#else // 128 kHz / 2 = 64 KHz -> This is the closest you can get, the prescaler is 2
+		cbi(ADCSRA, ADPS2);
+		cbi(ADCSRA, ADPS1);
+		sbi(ADCSRA, ADPS0);
+	#endif
+	// enable a2d conversions
+	sbi(ADCSRA, ADEN);
 #endif
 
-  // the bootloader connects pins 0 and 1 to the USART; disconnect them
-  // here so they can be used as normal digital i/o; they will be
-  // reconnected in Serial.begin()
+	// the bootloader connects pins 0 and 1 to the USART; disconnect them
+	// here so they can be used as normal digital i/o; they will be
+	// reconnected in Serial.begin()
 #if defined(UCSRB)
-  UCSRB = 0;
+	UCSRB = 0;
 #elif defined(UCSR0B)
-  UCSR0B = 0;
+	UCSR0B = 0;
 #endif
 }


### PR DESCRIPTION
This first fix fixes delay() inaccuracy when running the core with a 20Mhz crystal/resonator.
We now have an accuracy of 99.5% delay time (before the fix [it was 93.5%](https://github.com/MCUdude/MCUdude_corefiles/issues/13)).
I measured all the results with a Saleae Logic 8 Logic Analyzer, just to note on how you can review this fix.

Just for visualization on how inaccurate the old 93.5% actually is:
delay(1000) -> delays 1.067 seconds
delay(10000) -> delays 10.67 seconds
delay(20000) -> delays 21.34 seconds

With this fix you get the following results:
delay(1000) -> delays 1.005 seconds
delay(10000) -> delays 10.055 seconds
delay(20000) -> delays 20.110 seconds

(Sorry for 4 commits that changed the whole file. I realized too late that I accidentally added tabs)