### PR TITLE
Silghtly faster micros() for odd frequencies

### DIFF
--- a/wiring.c
+++ b/wiring.c
@@ -131,30 +131,7 @@ volatile unsigned char timer0_fract = 0;
 #ifndef CORRECT_EXACT_MICROS
 // variable is only needed in micros() calculation without exactness correction
 volatile unsigned long timer0_overflow_count = 0;
-#else
-// additional macros to use faster unsigned int multiply
-#if MICROSECONDS_PER_TIMER0_OVERFLOW >= (1UL << 16)
-// period too large, not defining CORRECT_BITS
-#elif MICROSECONDS_PER_TIMER0_OVERFLOW >= (1U << 15)
-#define CORRECT_BITS 8 
-#elif MICROSECONDS_PER_TIMER0_OVERFLOW >= (1U << 14)
-#define CORRECT_BITS 7
-#elif MICROSECONDS_PER_TIMER0_OVERFLOW >= (1U << 13)
-#define CORRECT_BITS 6
-#elif MICROSECONDS_PER_TIMER0_OVERFLOW >= (1U << 12)
-#define CORRECT_BITS 5
-#elif MICROSECONDS_PER_TIMER0_OVERFLOW >= (1U << 11)
-#define CORRECT_BITS 4
-#elif MICROSECONDS_PER_TIMER0_OVERFLOW >= (1U << 10)
-#define CORRECT_BITS 3
-#elif MICROSECONDS_PER_TIMER0_OVERFLOW >= (1U << 9)
-#define CORRECT_BITS 2
-#elif MICROSECONDS_PER_TIMER0_OVERFLOW >= (1U << 8)
-#define CORRECT_BITS 1
-#else
-#define CORRECT_BITS 0
 #endif
-#endif // CORRECT_EXACT_MICROS
 
 // timer0 interrupt routine ,- is called every time timer0 overflows
 #if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
@@ -289,14 +266,8 @@ unsigned long micros() {
      The leading part by m and f is long-term accurate.
      For the timer we just need to be close from below.
      Must never be too high, or micros jumps backwards. */
-  m = (((m << 7) - (m << 1) - m + f) << 3) + ((
-  #ifdef CORRECT_BITS
-      t * (unsigned int) (MICROSECONDS_PER_TIMER0_OVERFLOW >> CORRECT_BITS)
-  #else
-      #define CORRECT_BITS 0
-      t * (unsigned long) MICROSECONDS_PER_TIMER0_OVERFLOW
-  #endif
-    ) >> (8 - CORRECT_BITS));
+  m = (((m << 7) - (m << 1) - m + f) << 3) +
+      ((t * MICROSECONDS_PER_TIMER0_OVERFLOW) >> 8);
   return q ? m + MICROSECONDS_PER_TIMER0_OVERFLOW : m;
 #else
 

--- a/wiring.c
+++ b/wiring.c
@@ -37,14 +37,16 @@
 // the product 64 * 256 * 1000**2 overflows an unsigned long.  We resolve this
 // by recognizing that F_CPU is evenly divisible by 100 in all cases.  Thus, we
 // cancel a factor of 100 on both sides, which allows us to use long int.
-#define MICROSECONDS_PER_TIMER0_OVERFLOW (64L * 256L * 10000L / (F_CPU / 100L))
+// It also turns out that the code runs faster when this number is unsigned!
+#define MICROSECONDS_PER_TIMER0_OVERFLOW \
+  (64UL * 256UL * 10000UL / ((unsigned long) F_CPU / 100UL))
 #endif
 
 // the whole number of milliseconds per timer0 overflow
 // For 20MHz this would be 0 (because of 819)
 // For 16MHz this would be 1 (because of 1024)
-#define MILLIS_INC (MICROSECONDS_PER_TIMER0_OVERFLOW / 1000)
-#define MILLIS_INC_PLUS1 (MILLIS_INC + 1)
+#define MILLIS_INC (MICROSECONDS_PER_TIMER0_OVERFLOW / 1000U)
+#define MILLIS_INC_PLUS1 (MILLIS_INC + 1U)
 
 // the fractional number of milliseconds per timer0 overflow. we shift right
 // by three to fit these numbers into a byte. (for the clock speeds we care
@@ -52,9 +54,9 @@
 // For 16 MHz: 24 (1024 % 1000) gets shifted right by 3 which results in 3   (precision was lost)
 // For 20 MHz: 819 (819 % 1000) gets shifted right by 3 which results in 102 (precision was lost)
 // For 24 MHz: 682 (682 % 1000) gets shifted right by 3 which results in
-#define FRACT_INC ((MICROSECONDS_PER_TIMER0_OVERFLOW % 1000) >> 3)
+#define FRACT_INC ((MICROSECONDS_PER_TIMER0_OVERFLOW % 1000U) >> 3)
 // Shift right by 3 to fit in a byte (results in 125)
-#define FRACT_MAX (1000 >> 3)
+#define FRACT_MAX (1000U >> 3)
 
 volatile unsigned long timer0_millis = 0;
 volatile unsigned char timer0_fract = 0;


### PR DESCRIPTION
Hi again, while working on @SpenceKonde's tiny core, I came up with a `micros()` variant that is more optimized.
Here we have hardware multiply, and I'm replacing a 32 bit by a 16 bit version to save some 40 bytes of code.
This should run measurably faster!