### PR TITLE
Feature exact timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ micros, delay, delayMicroseconds).
 * 1 MHz
 
 
+### Adding further clock frequencies
+
+The calculation of `millis()`, `micros()` and `delay()` is automatic for
+arbitrary frequencies.  It is either exact or approximate to 8 ppm accuracy.
+The only thing required is adding support in `delayMicroseconds()`.
+
+
 ### Exactness of `delayMicroseconds()`
 
 The `delayMicroseconds(unsigned int us)` implementation is exact up to a few
@@ -58,8 +65,7 @@ For the clock speeds listed above, `micros()` is corrected to zero drift.
 Even for very long run times, the `micros()` function will precisely follow the
 oscillator used.
 
-Frequencies *not* listed above, for which `5**5 << 16` divided by `F_CPU / 10`
-leaves a *nonzero* remainder, are corrected to below 8 ppm drift
+Frequencies not listed above are either exact or corrected to below 8 ppm drift
 and in exact sync with `millis()`.
 
 Note that the result of `micros()` may jump up by several microseconds between
@@ -76,18 +82,20 @@ For the clock speeds listed above, `millis()` is corrected to zero drift.
 Even for very long run times, the `millis()` function will precisely follow the
 oscillator used.
 
-Frequencies *not* listed above, for which `5**5 << 16` divided by `F_CPU / 10`
-leaves a *nonzero* remainder, are corrected to below 8 ppm drift
+Frequencies not listed above are either exact or corrected to below 8 ppm drift
 and in exact sync with `micros()` and `delay()`.
 
 We do not register the rollover of the `unsigned long` millis counter that
 occurs every 49.7 days; such would have to be done in the user's program.
-Often this is not necessary:  The expression
+Often this is not necessary:  The code
 
-    (int) (millis() - millis_old)
+    if (millis() - millis_old >= interval) {
+      /* do something */
+      millis_old += interval;
+    }
 
-is correct even when rolling over provided `millis_old` is of type `unsigned long`
-and old and new time are no more than 32 seconds apart.
+is long-term accurate even when rolling over provided `millis_old` is of type
+`unsigned long`.
 
 For clock speeds of 16 MHz and below, the return value of `millis()`
 occasionally jumps up by more than one (notwithstanding low/zero drift).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ micros, delay, delayMicroseconds).
 * 12 MHz
 * 11.0592 MHz
 * 10 MHz
+* 9.216 MHz
 * 8 MHz
 * 7.3728 MHz
 * 6 MHz
@@ -45,7 +46,7 @@ micros, delay, delayMicroseconds).
 ### Exactness of `delayMicroseconds()`
 
 The `delayMicroseconds(unsigned int us)` implementation is exact up to a few
-cycles.
+cycles for the frequencies listed above.
 
 The maximum input parameter to work reliably is 10000 for 10 milliseconds.
 Its result is affected by interrupts occurring, which may prolong the delay.
@@ -57,9 +58,9 @@ For the clock speeds listed above, `micros()` is corrected to zero drift.
 Even for very long run times, the `micros()` function will precisely follow the
 oscillator used.
 
-Frequencies not listed above, for which `5**5 << 16` divided by `F_CPU / 10`
-leaves a nonzero remainder, are corrected to below 10ppm drift and at the same
-rate as `millis()`.
+Frequencies *not* listed above, for which `5**5 << 16` divided by `F_CPU / 10`
+leaves a *nonzero* remainder, are corrected to below 8 ppm drift
+and in exact sync with `millis()`.
 
 Note that the result of `micros()` may jump up by several microseconds between
 consecutive calls and rolls over after one hour and eleven minutes.
@@ -75,9 +76,9 @@ For the clock speeds listed above, `millis()` is corrected to zero drift.
 Even for very long run times, the `millis()` function will precisely follow the
 oscillator used.
 
-Frequencies not listed above, for which `5**5 << 16` divided by `F_CPU / 10`
-leaves a nonzero remainder, are corrected to below 10ppm drift and at the same
-rate as `micros()` and `delay()`.
+Frequencies *not* listed above, for which `5**5 << 16` divided by `F_CPU / 10`
+leaves a *nonzero* remainder, are corrected to below 8 ppm drift
+and in exact sync with `micros()` and `delay()`.
 
 We do not register the rollover of the `unsigned long` millis counter that
 occurs every 49.7 days; such would have to be done in the user's program.
@@ -90,4 +91,4 @@ and old and new time are no more than 32 seconds apart.
 
 For clock speeds of 16 MHz and below, the return value of `millis()`
 occasionally jumps up by more than one (notwithstanding low/zero drift).
-Thus, when relying on consecutive returns, run at 16.5 MHz or above.
+Thus, when relying on consecutive returns, run at 16.5 MHz or higher.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ micros, delay, delayMicroseconds).
 * 14.7456 MHz
 * 12 MHz
 * 11.0592 MHz
+* 10 MHz
 * 8 MHz
 * 7.3728 MHz
 * 6 MHz

--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ micros, delay, delayMicroseconds).
 * 20 MHz
 * 18.432 MHz
 * 18 MHz
+* 16.5 MHz
 * 16 MHz
 * 14.7456 MHz
 * 12 MHz
 * 11.0592 MHz
 * 8 MHz
 * 7.3728 MHz
+* 6 MHz
 * 4 MHz
 * 3.6864 MHz
 * 2 MHz
@@ -79,4 +81,4 @@ and old and new time are no more than 32 seconds apart.
 
 For clock speeds of 16 MHz and below, the return value of `millis()`
 occasionally jumps up by more than one (notwithstanding zero long-time drift).
-Thus, when relying on consecutive returns, run at 18 MHz or above.
+Thus, when relying on consecutive returns, run at 16.5 MHz or above.

--- a/README.md
+++ b/README.md
@@ -57,10 +57,14 @@ For the clock speeds listed above, `micros()` is corrected to zero drift.
 Even for very long run times, the `micros()` function will precisely follow the
 oscillator used.
 
-Note that the result may jump up by several microseconds between consecutive
-calls and rolls over after one hour and eleven minutes.
+Frequencies not listed above, for which `5**5 << 16` divided by `F_CPU / 10`
+leaves a nonzero remainder, are corrected to below 10ppm drift and at the same
+rate as `millis()`.
 
-The `delay()` function uses `micros()` internally and inherits its zero drift,
+Note that the result of `micros()` may jump up by several microseconds between
+consecutive calls and rolls over after one hour and eleven minutes.
+
+The `delay()` function uses `micros()` internally and inherits its drift accuracy
 with slight variations due to function call overhead and processing.
 It is immune to interrupts and thus long-term accurate.
 
@@ -70,6 +74,10 @@ It is immune to interrupts and thus long-term accurate.
 For the clock speeds listed above, `millis()` is corrected to zero drift.
 Even for very long run times, the `millis()` function will precisely follow the
 oscillator used.
+
+Frequencies not listed above, for which `5**5 << 16` divided by `F_CPU / 10`
+leaves a nonzero remainder, are corrected to below 10ppm drift and at the same
+rate as `micros()` and `delay()`.
 
 We do not register the rollover of the `unsigned long` millis counter that
 occurs every 49.7 days; such would have to be done in the user's program.
@@ -81,5 +89,5 @@ is correct even when rolling over provided `millis_old` is of type `unsigned lon
 and old and new time are no more than 32 seconds apart.
 
 For clock speeds of 16 MHz and below, the return value of `millis()`
-occasionally jumps up by more than one (notwithstanding zero long-time drift).
+occasionally jumps up by more than one (notwithstanding low/zero drift).
 Thus, when relying on consecutive returns, run at 16.5 MHz or above.

--- a/wiring.c
+++ b/wiring.c
@@ -86,6 +86,7 @@ volatile unsigned char timer0_fract = 0;
     F_CPU == 14745600L || \
     F_CPU == 12000000L || \
     F_CPU == 11059200L || \
+    F_CPU == 10000000L || \
     F_CPU ==  7372800L || \
     F_CPU ==  6000000L || \
     F_CPU ==  3686400L || \
@@ -122,6 +123,9 @@ volatile unsigned char timer0_fract = 0;
 #elif F_CPU == 11059200L        // for 11.0592 MHz we get 60 + 5./27.
 #define CORRECT_BRUTE 5
 #define CORRECT_ROLL 27
+#elif F_CPU == 10000000L        // for 10 MHz we get 79.8, off by 4./5.
+#define CORRECT_HI
+#define CORRECT_ROLL 5
 #elif F_CPU == 7372800L         // for 7.372800 MHz we get 27 + 7./9.
 #define CORRECT_BRUTE 7
 #define CORRECT_ROLL 9
@@ -703,14 +707,14 @@ void delayMicroseconds(unsigned int us)
   if (us <= 2) return; // = 3 cycles, (4 when true)
 
   // the following loop takes 2/5 of a microsecond (4 cycles)
-  // per iteration, so execute it three times for each microsecond of
-  // delay requested.
+  // per iteration, so execute it five times for every 2 microseconds
+  // of delay requested.
   us = (us << 1) + (us >> 1); // x2.5 us, = 7 cycles
 
   // account for the time taken in the preceeding commands.
-  // we just burned 22 (24) cycles above, remove 5, (5*4=20)
-  // us is at least 20 so we can substract 5
-  us -= 5; // = 2 cycles
+  // we burn 22 (24) cycles above plus 2 below, remove 6, (6*4=24)
+  // us is at least 7 so we can subtract 6
+  us -= 6; // = 2 cycles
 
 #elif F_CPU >= 9216000L
   // the overhead of the function call is 14 (16) cycles which is ~1.5 us

--- a/wiring.c
+++ b/wiring.c
@@ -39,7 +39,7 @@
 // cancel a factor of 100 on both sides, which allows us to use long int.
 // It also turns out that the code runs faster when this number is unsigned!
 #define MICROSECONDS_PER_TIMER0_OVERFLOW \
-  (64UL * 256UL * 10000UL / ((unsigned long) F_CPU / 100UL))
+  (64UL * 256UL * 10000UL / (F_CPU / 100UL))
 #endif
 
 // the whole number of milliseconds per timer0 overflow


### PR DESCRIPTION
I've done a couple last things to hopefully close the book on millis and micros.

 * I've added exact support for the 6, 9.216, 10 and 16.5 MHz frequencies.
 * I've added generic preprocessor code that makes millis, micros and delay work to high accuracy for *any* frequency. You can `#define F_CPU 12345678L` and they will just work. The only thing to do when adding yet another one is to extend `delayMicroseconds()`.
 * The power-of-two-frequencies *should* not have changed, but it won't hurt to verify that code size and execution time are as before.

Please let me know if anything does not perform up to spec.