### PR TITLE
Provide missing delete operators introduced in C++14

### DIFF
--- a/new.cpp
+++ b/new.cpp
@@ -34,3 +34,18 @@ void operator delete[](void * ptr) {
   free(ptr);
 }
 
+
+// C++14 introduces additional delete operators
+#if __cplusplus >= 201402L
+
+void operator delete(void * ptr, size_t)
+{
+    ::operator delete(ptr);
+}
+
+void operator delete[](void * ptr, size_t)
+{
+    ::operator delete(ptr);
+}
+
+#endif // end language is C++14 or greater

--- a/new.h
+++ b/new.h
@@ -26,5 +26,11 @@ void * operator new[](size_t size);
 void operator delete(void * ptr);
 void operator delete[](void * ptr);
 
+// C++14 introduces additional delete operators
+#if __cplusplus >= 201402L
+void operator delete(void * ptr, size_t);
+void operator delete[](void * ptr, size_t);
+#endif // end language is C++14 or greater
+
 #endif
 


### PR DESCRIPTION
As discussed previously, this pull request will solve the missing delete operator methods found a linking when telling the compiler to be in C++14, C++17, or later modes.